### PR TITLE
feat: add init command to scaffold config and example test

### DIFF
--- a/packages/mobilewright/package.json
+++ b/packages/mobilewright/package.json
@@ -29,7 +29,8 @@
     "directory": "packages/mobilewright"
   },
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "dependencies": {
     "@mobilewright/core": "^0.0.1",

--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -2,7 +2,9 @@
 
 import { Command } from 'commander';
 import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { createRequire } from 'node:module';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
@@ -13,6 +15,7 @@ const _require = createRequire(import.meta.url);
 const _pkg = _require('../package.json') as { version: string };
 
 const HTML_REPORT_DIR = 'mobilewright-report';
+const TEMPLATES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'templates');
 
 const program = new Command();
 program.name('mobilewright');
@@ -154,6 +157,27 @@ program
     }
 
     if (checks.some(c => c.status === 'error')) process.exitCode = 1;
+  });
+
+// ── init ───────────────────────────────────────────────────────────────
+program
+  .command('init')
+  .description('scaffold a mobilewright.config.ts and example test in the current directory')
+  .action(async () => {
+    const files = [
+      { src: 'mobilewright.config.ts', dest: resolve(process.cwd(), 'mobilewright.config.ts') },
+      { src: 'example.test.ts', dest: resolve(process.cwd(), 'example.test.ts') },
+    ];
+
+    for (const { src, dest } of files) {
+      if (existsSync(dest)) {
+        console.log(`skipped  ${src} (already exists)`);
+        continue;
+      }
+      const content = await readFile(resolve(TEMPLATES_DIR, src), 'utf8');
+      await writeFile(dest, content, 'utf8');
+      console.log(`created  ${src}`);
+    }
   });
 
 function padRight(str: string, len: number): string {

--- a/packages/mobilewright/templates/example.test.ts
+++ b/packages/mobilewright/templates/example.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@mobilewright/test';
+
+test('app launches and shows home screen', async ({ screen }) => {
+  await expect(screen.getByText('Welcome')).toBeVisible();
+});

--- a/packages/mobilewright/templates/mobilewright.config.ts
+++ b/packages/mobilewright/templates/mobilewright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'mobilewright';
+
+export default defineConfig({
+  platform: 'ios',
+  bundleId: 'com.example.myapp',
+  deviceName: /iPhone 16/,
+  timeout: 10_000,
+});


### PR DESCRIPTION
## Summary

- Adds `mobilewright init` CLI command that copies pre-bundled template files into the user's project directory
- Ships `mobilewright.config.ts` and `example.test.ts` as static templates inside the npm package (`templates/` dir)
- Skips files that already exist to avoid clobbering existing work
- Added `"templates"` to the `files` array in `package.json` so the directory is included in the published package

## Usage

```
npx mobilewright init
# created  mobilewright.config.ts
# created  example.test.ts
```

## Test plan

- [ ] Run `mobilewright init` in an empty directory — both files are created
- [ ] Run `mobilewright init` again — both files report `skipped (already exists)`
- [ ] Verify `mobilewright.config.ts` matches the config example in the docs
- [ ] Verify `example.test.ts` runs without errors against a connected device