### PR TITLE
feat: improve React Native support with new locators and assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,16 +205,18 @@ await expect(locator).toBeVisible({ timeout: 10_000 });
 
 | Role | iOS | Android |
 |---|---|---|
-| `button` | Button, ImageButton | Button, ImageButton |
-| `textfield` | TextField, SecureTextField, SearchField | EditText |
-| `text` | StaticText | TextView, Text |
-| `image` | Image | ImageView |
+| `button` | Button, ImageButton | Button, ImageButton, ReactViewGroup* |
+| `textfield` | TextField, SecureTextField, SearchField | EditText, ReactEditText |
+| `text` | StaticText | TextView, Text, ReactTextView |
+| `image` | Image | ImageView, ReactImageView |
 | `switch` | Switch | Switch, Toggle |
 | `checkbox` | -- | Checkbox |
 | `slider` | Slider | SeekBar |
-| `list` | Table, CollectionView, ScrollView | ListView, RecyclerView |
+| `list` | Table, CollectionView, ScrollView | ListView, RecyclerView, ReactScrollView |
 | `header` | NavigationBar | Toolbar |
 | `link` | Link | Link |
+
+\* ReactViewGroup matches `button` only when the element has `clickable="true"` or `accessible="true"` in its raw attributes, to avoid false positives since React Native uses ReactViewGroup for all container views.
 
 Falls back to direct type matching if no mapping exists.
 
@@ -294,4 +296,20 @@ ID                                      Name                     Platform  Type 
 # Run all unit tests
 npm test
 ```
+
+## Framework Support
+
+| Framework | iOS | Android | Notes |
+|---|---|---|---|
+| UIKit / Storyboards | ✅ | — | Full native element types, all locators work |
+| SwiftUI | ✅ | — | Maps to standard `XCUIElementType` accessibility tree |
+| Jetpack Compose | — | ✅ | Renders to native Android accessibility nodes |
+| Android Views (XML layouts) | — | ✅ | Full native element types, all locators work |
+| React Native | ✅ | ✅ | Uses real native components; RN-specific types mapped to roles |
+| Expo | ✅ | ✅ | Same as React Native (Expo builds to RN) |
+| Flutter | ⏳ | ⏳ | Renders via Skia/Impeller, not native views — requires Dart VM Service driver |
+| .NET MAUI | ✅ | ✅ | Compiles to native controls on both platforms |
+| Kotlin Multiplatform (shared UI) | ⏳ | ✅ | Android native works; iOS Compose Multiplatform support in progress |
+| Cordova / Capacitor | ✅ | ✅ | WebView content accessible via native accessibility tree |
+| NativeScript | ✅ | ✅ | Renders to native views on both platforms |
 

--- a/packages/driver-mobilecli/src/parsers/android-hierarchy-parser.ts
+++ b/packages/driver-mobilecli/src/parsers/android-hierarchy-parser.ts
@@ -37,11 +37,13 @@ function androidNodeFromAttrs(
     : fullClass;
 
   // resource-id often looks like "com.example:id/login_button"
-  // Extract just the id part after "/"
+  // Extract just the id part after "/" for short matching
   const rawResourceId = attrs.get('resource-id') || '';
   const identifier = rawResourceId.includes('/')
     ? rawResourceId.split('/').pop()
     : rawResourceId || undefined;
+  // Keep the full resource-id for exact matching (e.g. Appium migration)
+  const resourceId = rawResourceId || undefined;
 
   const contentDesc = attrs.get('content-desc') || '';
   const text = attrs.get('text') || '';
@@ -55,6 +57,7 @@ function androidNodeFromAttrs(
     type,
     label: contentDesc || undefined,
     identifier: identifier || undefined,
+    resourceId,
     value: undefined,
     text: text || undefined,
     placeholder: attrs.get('hint') || undefined,
@@ -62,6 +65,9 @@ function androidNodeFromAttrs(
     isEnabled: attrs.get('enabled') === 'true',
     isSelected: attrs.get('selected') === 'true' ? true : undefined,
     isFocused: attrs.get('focused') === 'true' ? true : undefined,
+    isChecked: attrs.get('checkable') === 'true'
+      ? attrs.get('checked') === 'true'
+      : undefined,
     bounds: parseBounds(attrs.get('bounds') || ''),
     children: [],
     raw,

--- a/packages/mobilewright-core/src/expect.test.ts
+++ b/packages/mobilewright-core/src/expect.test.ts
@@ -220,6 +220,164 @@ test.describe('expect', () => {
     });
   });
 
+  test.describe('toBeDisabled', () => {
+    test('passes when element is disabled', async () => {
+      const disabledTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'Button',
+              label: 'Submit',
+              identifier: 'disabledBtn',
+              isEnabled: false,
+              bounds: { x: 20, y: 100, width: 200, height: 50 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(disabledTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'disabledBtn' });
+      await mwExpect(locator).toBeDisabled();
+    });
+
+    test('fails when element is enabled', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'testId', value: 'submitBtn' });
+      await expect(
+        mwExpect(locator).toBeDisabled({ timeout: 200 }),
+      ).rejects.toThrow(ExpectError);
+    });
+  });
+
+  test.describe('toBeSelected', () => {
+    test('passes when element is selected', async () => {
+      const selectedTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'Tab',
+              label: 'Home',
+              identifier: 'homeTab',
+              isSelected: true,
+              bounds: { x: 0, y: 0, width: 100, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(selectedTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'homeTab' });
+      await mwExpect(locator).toBeSelected();
+    });
+  });
+
+  test.describe('toHaveFocus', () => {
+    test('passes when element is focused', async () => {
+      const focusedTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'TextField',
+              label: 'Email',
+              identifier: 'emailField',
+              isFocused: true,
+              bounds: { x: 0, y: 0, width: 300, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(focusedTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'emailField' });
+      await mwExpect(locator).toHaveFocus();
+    });
+  });
+
+  test.describe('toBeChecked', () => {
+    test('passes when element is checked', async () => {
+      const checkedTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'Checkbox',
+              label: 'Agree',
+              identifier: 'agreeCheck',
+              isChecked: true,
+              bounds: { x: 0, y: 0, width: 44, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(checkedTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'agreeCheck' });
+      await mwExpect(locator).toBeChecked();
+    });
+
+    test('not.toBeChecked passes when unchecked', async () => {
+      const uncheckedTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'Checkbox',
+              label: 'Agree',
+              identifier: 'agreeCheck',
+              isChecked: false,
+              bounds: { x: 0, y: 0, width: 44, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(uncheckedTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'agreeCheck' });
+      await mwExpect(locator).not.toBeChecked();
+    });
+  });
+
+  test.describe('toHaveValue', () => {
+    test('passes with exact value match', async () => {
+      const valueTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'Slider',
+              label: 'Volume',
+              identifier: 'volumeSlider',
+              value: '75%',
+              bounds: { x: 0, y: 0, width: 300, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(valueTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'volumeSlider' });
+      await mwExpect(locator).toHaveValue('75%');
+    });
+
+    test('passes with regex value match', async () => {
+      const valueTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'Slider',
+              label: 'Volume',
+              identifier: 'volumeSlider',
+              value: '75%',
+              bounds: { x: 0, y: 0, width: 300, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(valueTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'volumeSlider' });
+      await mwExpect(locator).toHaveValue(/\d+%/);
+    });
+  });
+
   test.describe('auto-retry', () => {
     test('retries until assertion passes', async () => {
       const initialTree: ViewNode[] = [

--- a/packages/mobilewright-core/src/expect.ts
+++ b/packages/mobilewright-core/src/expect.ts
@@ -66,6 +66,68 @@ class LocatorAssertions {
     );
   }
 
+  async toBeDisabled(opts?: ExpectOptions): Promise<void> {
+    await this.retryUntil(
+      () => this.locator.isEnabled({ timeout: 0 }),
+      (enabled) => (this.negated ? enabled : !enabled),
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      this.negated
+        ? 'Expected element to NOT be disabled, but it was'
+        : 'Expected element to be disabled, but it was not',
+    );
+  }
+
+  async toBeSelected(opts?: ExpectOptions): Promise<void> {
+    await this.retryUntil(
+      () => this.locator.isSelected({ timeout: 0 }),
+      (selected) => (this.negated ? !selected : selected),
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      this.negated
+        ? 'Expected element to NOT be selected, but it was'
+        : 'Expected element to be selected, but it was not',
+    );
+  }
+
+  async toHaveFocus(opts?: ExpectOptions): Promise<void> {
+    await this.retryUntil(
+      () => this.locator.isFocused({ timeout: 0 }),
+      (focused) => (this.negated ? !focused : focused),
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      this.negated
+        ? 'Expected element to NOT have focus, but it did'
+        : 'Expected element to have focus, but it did not',
+    );
+  }
+
+  async toBeChecked(opts?: ExpectOptions): Promise<void> {
+    await this.retryUntil(
+      () => this.locator.isChecked({ timeout: 0 }),
+      (checked) => (this.negated ? !checked : checked),
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      this.negated
+        ? 'Expected element to NOT be checked, but it was'
+        : 'Expected element to be checked, but it was not',
+    );
+  }
+
+  async toHaveValue(expected: string | RegExp, opts?: ExpectOptions): Promise<void> {
+    let lastValue = '';
+    await this.retryUntil(
+      async () => {
+        try { lastValue = await this.locator.getValue({ timeout: 0 }); } catch { lastValue = ''; }
+        return lastValue;
+      },
+      (value) => {
+        const matches = expected instanceof RegExp ? expected.test(value) : value === expected;
+        return this.negated ? !matches : matches;
+      },
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      () => this.negated
+        ? `Expected element NOT to have value "${expected}", but got "${lastValue}"`
+        : `Expected element to have value "${expected}", but got "${lastValue}"`,
+    );
+  }
+
   private async assertText(
     predicate: (text: string) => boolean,
     expected: string | RegExp,

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -47,6 +47,10 @@ export class Locator {
     return this.child({ kind: 'role', value: role, name: opts?.name });
   }
 
+  getByPlaceholder(placeholder: string, opts?: { exact?: boolean }): Locator {
+    return this.child({ kind: 'placeholder', value: placeholder, exact: opts?.exact });
+  }
+
   private child(childStrategy: LocatorStrategy): Locator {
     return new Locator(
       this.driver,
@@ -105,9 +109,29 @@ export class Locator {
     return node !== null && node.isEnabled;
   }
 
+  async isSelected(opts?: { timeout?: number }): Promise<boolean> {
+    const node = await this.resolve(opts?.timeout ?? 0);
+    return node !== null && node.isSelected === true;
+  }
+
+  async isFocused(opts?: { timeout?: number }): Promise<boolean> {
+    const node = await this.resolve(opts?.timeout ?? 0);
+    return node !== null && node.isFocused === true;
+  }
+
+  async isChecked(opts?: { timeout?: number }): Promise<boolean> {
+    const node = await this.resolve(opts?.timeout ?? 0);
+    return node !== null && node.isChecked === true;
+  }
+
   async getText(opts?: { timeout?: number }): Promise<string> {
     const node = await this.resolveVisible(opts?.timeout);
     return node.text ?? node.label ?? node.value ?? '';
+  }
+
+  async getValue(opts?: { timeout?: number }): Promise<string> {
+    const node = await this.resolveVisible(opts?.timeout);
+    return node.value ?? '';
   }
 
   async waitFor(opts?: {

--- a/packages/mobilewright-core/src/query-engine.test.ts
+++ b/packages/mobilewright-core/src/query-engine.test.ts
@@ -264,3 +264,114 @@ test.describe('queryAll with flat hierarchy (bounds-based chains)', () => {
     expect(results).toHaveLength(0);
   });
 });
+
+test.describe('React Native Android role mapping', () => {
+  const rnTree: ViewNode[] = [
+    node({
+      type: 'ReactViewGroup',
+      label: 'Login',
+      raw: { clickable: 'true', accessible: 'true' },
+      children: [
+        node({ type: 'ReactTextView', text: 'Hello World' }),
+        node({
+          type: 'ReactEditText',
+          placeholder: 'Enter email',
+          raw: { hint: 'Enter email' },
+        }),
+        node({ type: 'ReactImageView', label: 'Avatar' }),
+        node({
+          type: 'ReactScrollView',
+          children: [
+            node({ type: 'ReactTextView', text: 'Item 1' }),
+          ],
+        }),
+      ],
+    }),
+    node({
+      type: 'ReactViewGroup',
+      label: 'Container',
+      raw: { clickable: 'false', accessible: 'false' },
+    }),
+  ];
+
+  test('ReactViewGroup with clickable=true matches button role', () => {
+    const results = queryAll(rnTree, { kind: 'role', value: 'button' });
+    expect(results).toHaveLength(1);
+    expect(results[0].label).toBe('Login');
+  });
+
+  test('ReactViewGroup without clickable does not match button role', () => {
+    const results = queryAll(rnTree, { kind: 'role', value: 'button', name: 'Container' });
+    expect(results).toHaveLength(0);
+  });
+
+  test('ReactTextView matches text role', () => {
+    const results = queryAll(rnTree, { kind: 'role', value: 'text' });
+    expect(results).toHaveLength(2);
+  });
+
+  test('ReactEditText matches textfield role', () => {
+    const results = queryAll(rnTree, { kind: 'role', value: 'textfield' });
+    expect(results).toHaveLength(1);
+  });
+
+  test('ReactImageView matches image role', () => {
+    const results = queryAll(rnTree, { kind: 'role', value: 'image' });
+    expect(results).toHaveLength(1);
+    expect(results[0].label).toBe('Avatar');
+  });
+
+  test('ReactScrollView matches list role', () => {
+    const results = queryAll(rnTree, { kind: 'role', value: 'list' });
+    expect(results).toHaveLength(1);
+  });
+});
+
+test.describe('placeholder strategy', () => {
+  const tree: ViewNode[] = [
+    node({ type: 'TextField', placeholder: 'Enter email' }),
+    node({ type: 'TextField', placeholder: 'Enter password' }),
+    node({ type: 'Button', label: 'Submit' }),
+  ];
+
+  test('finds by exact placeholder', () => {
+    const results = queryAll(tree, { kind: 'placeholder', value: 'Enter email' });
+    expect(results).toHaveLength(1);
+    expect(results[0].placeholder).toBe('Enter email');
+  });
+
+  test('finds by substring placeholder (exact=false)', () => {
+    const results = queryAll(tree, { kind: 'placeholder', value: 'enter', exact: false });
+    expect(results).toHaveLength(2);
+  });
+
+  test('returns empty when no placeholder matches', () => {
+    const results = queryAll(tree, { kind: 'placeholder', value: 'Phone' });
+    expect(results).toHaveLength(0);
+  });
+});
+
+test.describe('testId with resourceId', () => {
+  const tree: ViewNode[] = [
+    node({
+      type: 'EditText',
+      identifier: 'login_button',
+      resourceId: 'com.example:id/login_button',
+    }),
+  ];
+
+  test('matches short identifier', () => {
+    const results = queryAll(tree, { kind: 'testId', value: 'login_button' });
+    expect(results).toHaveLength(1);
+  });
+
+  test('matches full resourceId', () => {
+    const results = queryAll(tree, { kind: 'testId', value: 'com.example:id/login_button' });
+    expect(results).toHaveLength(1);
+  });
+
+  test('does not match partial resourceId', () => {
+    const results = queryAll(tree, { kind: 'testId', value: 'example:id/login_button' });
+    expect(results).toHaveLength(0);
+  });
+});

--- a/packages/mobilewright-core/src/query-engine.ts
+++ b/packages/mobilewright-core/src/query-engine.ts
@@ -7,6 +7,7 @@ export type LocatorStrategy =
   | { kind: 'text'; value: string | RegExp; exact?: boolean }
   | { kind: 'type'; value: string }
   | { kind: 'role'; value: string; name?: string | RegExp }
+  | { kind: 'placeholder'; value: string; exact?: boolean }
   | { kind: 'chain'; parent: LocatorStrategy; child: LocatorStrategy };
 
 /**
@@ -74,7 +75,9 @@ function matchesStrategy(
         : node.label === strategy.value;
 
     case 'testId':
-      return node.identifier === strategy.value;
+      if (node.identifier === strategy.value) return true;
+      if (node.resourceId && node.resourceId === strategy.value) return true;
+      return false;
 
     case 'text': {
       const nodeText = node.text ?? node.label ?? node.value ?? '';
@@ -102,6 +105,12 @@ function matchesStrategy(
       }
       return true;
 
+    case 'placeholder':
+      if (!node.placeholder) return false;
+      return strategy.exact === false
+        ? node.placeholder.toLowerCase().includes(strategy.value.toLowerCase())
+        : node.placeholder === strategy.value;
+
     case 'chain':
       // Handled above in queryAll
       return false;
@@ -110,13 +119,13 @@ function matchesStrategy(
 
 const ROLE_TYPE_MAP: Record<string, string[]> = {
   button: ['button', 'imagebutton'],
-  textfield: ['textfield', 'securetextfield', 'edittext', 'searchfield'],
-  text: ['statictext', 'textview', 'text'],
-  image: ['image', 'imageview'],
+  textfield: ['textfield', 'securetextfield', 'edittext', 'searchfield', 'reactedittext'],
+  text: ['statictext', 'textview', 'text', 'reacttextview'],
+  image: ['image', 'imageview', 'reactimageview'],
   switch: ['switch', 'toggle'],
   checkbox: ['checkbox'],
   slider: ['slider', 'seekbar'],
-  list: ['table', 'collectionview', 'listview', 'recyclerview', 'scrollview'],
+  list: ['table', 'collectionview', 'listview', 'recyclerview', 'scrollview', 'reactscrollview'],
   listitem: ['cell', 'linearlayout', 'relativelayout', 'other'],
   tab: ['tab', 'tabbar'],
   link: ['link'],
@@ -126,6 +135,16 @@ const ROLE_TYPE_MAP: Record<string, string[]> = {
 function matchesRole(node: ViewNode, role: string): boolean {
   const normalizedType = node.type.toLowerCase();
   const roleTypes = ROLE_TYPE_MAP[role.toLowerCase()];
+
+  // React Native's ReactViewGroup is used for everything — only treat it as a
+  // button when the element is explicitly marked clickable or accessible.
+  if (normalizedType === 'reactviewgroup') {
+    if (role.toLowerCase() === 'button') {
+      return node.raw?.['clickable'] === 'true' || node.raw?.['accessible'] === 'true';
+    }
+    return false;
+  }
+
   if (roleTypes) {
     return roleTypes.includes(normalizedType);
   }

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -11,6 +11,8 @@ export interface ViewNode {
   type: string;
   label?: string;
   identifier?: string;
+  /** Full Android resource-id (e.g. "com.example:id/login_button") */
+  resourceId?: string;
   value?: string;
   text?: string;
   placeholder?: string;
@@ -19,6 +21,7 @@ export interface ViewNode {
   isEnabled: boolean;
   isSelected?: boolean;
   isFocused?: boolean;
+  isChecked?: boolean;
 
   bounds: Bounds;
   children: ViewNode[];


### PR DESCRIPTION
## Summary

- **React Native role mapping** — adds `ReactTextView`, `ReactEditText`, `ReactImageView`, `ReactScrollView` to `ROLE_TYPE_MAP` so `getByRole('text')`, `getByRole('textfield')`, `getByRole('image')`, `getByRole('list')` work on Android RN apps. `ReactViewGroup` maps to `button` only when `clickable="true"` or `accessible="true"` to avoid false positives.
- **Full resource-id matching** — stores `resourceId` on `ViewNode` so `getByTestId('com.example:id/login_button')` works alongside the existing short form `getByTestId('login_button')`. Useful for Appium migration.
- **`getByPlaceholder()` locator** — new locator strategy for matching elements by placeholder text (Android `hint`, iOS `placeholderValue`). Supports exact and substring matching.
- **New assertions** — `toBeDisabled()`, `toBeSelected()`, `toHaveFocus()`, `toBeChecked()`, `toHaveValue()` with full `.not` negation and auto-retry support.
- **New Locator queries** — `isSelected()`, `isFocused()`, `isChecked()`, `getValue()`.
- **`isChecked` on ViewNode** — populated from Android `checkable`/`checked` attributes.
- **Framework support table** in README showing what works out of the box.

## Test plan

- [x] All 77 existing + new unit tests pass
- [ ] Verify role mapping against a real React Native app on Android
- [ ] Verify `getByPlaceholder` on both iOS and Android
- [ ] Review framework support table for accuracy