### PR TITLE
fix: convert swipe direction to coordinates for mobilecli RPC

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -159,12 +159,32 @@ export class MobilecliDriver implements MobilewrightDriver {
   }
 
   async swipe(direction: SwipeDirection, opts?: SwipeOptions): Promise<void> {
+    const screen = await this.getScreenSize();
+    const centerX = screen.width / 2;
+    const centerY = screen.height / 2;
+
+    const startX = opts?.startX ?? centerX;
+    const startY = opts?.startY ?? centerY;
+
+    const isHorizontal = direction === 'left' || direction === 'right';
+    const defaultDistance = (isHorizontal ? screen.width : screen.height) * 0.5;
+    const distance = opts?.distance ?? defaultDistance;
+
+    let endX = startX;
+    let endY = startY;
+    switch (direction) {
+      case 'up':    endY = startY - distance; break;
+      case 'down':  endY = startY + distance; break;
+      case 'left':  endX = startX - distance; break;
+      case 'right': endX = startX + distance; break;
+    }
+
     await this.call('device.io.swipe', {
-      direction,
-      ...(opts?.distance !== undefined && { distance: opts.distance }),
+      x1: Math.round(startX),
+      y1: Math.round(startY),
+      x2: Math.round(endX),
+      y2: Math.round(endY),
       ...(opts?.duration !== undefined && { duration: opts.duration }),
-      ...(opts?.startX !== undefined && { startX: opts.startX }),
-      ...(opts?.startY !== undefined && { startY: opts.startY }),
     });
   }
 


### PR DESCRIPTION
## Summary

- The mobilecli `device.io.swipe` RPC expects raw `x1, y1, x2, y2` coordinates, but the driver was passing `direction` as a string parameter, causing `'x1' is required` errors at runtime
- The driver now fetches screen size and computes start/end coordinates from the direction, optional `startX`/`startY`, and `distance` (defaults to 50% of the relevant screen dimension from center)

## Test plan

- [x] Verified with Milliways iOS app — swipe gestures now work correctly on simulator
- [x] All 5 integration tests pass (welcome screen, menu browsing with swipe, item detail, quantity, full order flow)