### PR TITLE
feat: support plain value assertions in expect()

### DIFF
--- a/packages/mobilewright-core/src/expect.test.ts
+++ b/packages/mobilewright-core/src/expect.test.ts
@@ -417,6 +417,83 @@ test.describe('expect', () => {
     });
   });
 
+  test.describe('value assertions', () => {
+    test('toBe passes with equal values', () => {
+      mwExpect(42).toBe(42);
+      mwExpect('hello').toBe('hello');
+      mwExpect(true).toBe(true);
+    });
+
+    test('toBe fails with different values', () => {
+      expect(() => mwExpect(236.25).toBe(431.93)).toThrow(ExpectError);
+    });
+
+    test('toBe uses Object.is semantics', () => {
+      expect(() => mwExpect(NaN).toBe(NaN)).not.toThrow();
+      expect(() => mwExpect(0).toBe(-0)).toThrow(ExpectError);
+    });
+
+    test('not.toBe passes with different values', () => {
+      mwExpect(1).not.toBe(2);
+    });
+
+    test('not.toBe fails with equal values', () => {
+      expect(() => mwExpect(42).not.toBe(42)).toThrow(ExpectError);
+    });
+
+    test('toEqual passes with deep equality', () => {
+      mwExpect({ a: 1, b: [2, 3] }).toEqual({ a: 1, b: [2, 3] });
+    });
+
+    test('toEqual fails with different objects', () => {
+      expect(() => mwExpect({ a: 1 }).toEqual({ a: 2 })).toThrow(ExpectError);
+    });
+
+    test('toBeTruthy and toBeFalsy', () => {
+      mwExpect(1).toBeTruthy();
+      mwExpect('yes').toBeTruthy();
+      mwExpect(0).toBeFalsy();
+      mwExpect('').toBeFalsy();
+      mwExpect(null).toBeFalsy();
+    });
+
+    test('toBeGreaterThan and toBeLessThan', () => {
+      mwExpect(10).toBeGreaterThan(5);
+      mwExpect(5).toBeLessThan(10);
+      expect(() => mwExpect(5).toBeGreaterThan(10)).toThrow(ExpectError);
+      expect(() => mwExpect(10).toBeLessThan(5)).toThrow(ExpectError);
+    });
+
+    test('toBeCloseTo passes within precision', () => {
+      mwExpect(0.1 + 0.2).toBeCloseTo(0.3);
+      mwExpect(1.005).toBeCloseTo(1.0, 1);
+    });
+
+    test('toBeCloseTo fails outside precision', () => {
+      expect(() => mwExpect(0.5).toBeCloseTo(1.0)).toThrow(ExpectError);
+    });
+
+    test('toContain works with arrays and strings', () => {
+      mwExpect([1, 2, 3]).toContain(2);
+      mwExpect('hello world').toContain('world');
+      expect(() => mwExpect([1, 2]).toContain(5)).toThrow(ExpectError);
+    });
+
+    test('toBeNull and toBeUndefined', () => {
+      mwExpect(null).toBeNull();
+      mwExpect(undefined).toBeUndefined();
+      expect(() => mwExpect(0).toBeNull()).toThrow(ExpectError);
+      expect(() => mwExpect(null).toBeUndefined()).toThrow(ExpectError);
+    });
+
+    test('locators still route to LocatorAssertions', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'testId', value: 'submitBtn' });
+      // This should use LocatorAssertions, not ValueAssertions
+      await mwExpect(locator).toBeVisible();
+    });
+  });
+
   test.describe('auto-retry', () => {
     test('retries until assertion passes', async () => {
       const initialTree: ViewNode[] = [

--- a/packages/mobilewright-core/src/expect.ts
+++ b/packages/mobilewright-core/src/expect.ts
@@ -9,15 +9,21 @@ export interface ExpectOptions {
 }
 
 /**
- * Playwright-style expect with auto-retry for mobile locators.
+ * Playwright-style expect for mobile locators and plain values.
  *
  * Usage:
  *   expect(locator).toBeVisible()
  *   expect(locator).not.toBeVisible()
  *   expect(locator).toHaveText('Hello')
+ *   expect(42).toBe(42)
  */
-export function expect(locator: Locator): LocatorAssertions {
-  return new LocatorAssertions(locator, false);
+export function expect(actual: Locator): LocatorAssertions;
+export function expect<T>(actual: T): ValueAssertions<T>;
+export function expect(actual: unknown): any {
+  if (actual && typeof actual === 'object' && 'tap' in actual && 'getText' in actual) {
+    return new LocatorAssertions(actual as Locator, false);
+  }
+  return new ValueAssertions(actual, false);
 }
 
 class LocatorAssertions {
@@ -154,6 +160,76 @@ class LocatorAssertions {
       await sleep(POLL_INTERVAL);
     }
   }
+}
+
+class ValueAssertions<T> {
+  constructor(
+    private readonly actual: T,
+    private readonly negated: boolean,
+  ) {}
+
+  get not(): ValueAssertions<T> {
+    return new ValueAssertions(this.actual, !this.negated);
+  }
+
+  toBe(expected: T): void {
+    const pass = Object.is(this.actual, expected);
+    this.assert(pass, `Expected ${fmt(expected)}, but received ${fmt(this.actual)}`);
+  }
+
+  toEqual(expected: T): void {
+    const pass = JSON.stringify(this.actual) === JSON.stringify(expected);
+    this.assert(pass, `Expected ${fmt(expected)}, but received ${fmt(this.actual)}`);
+  }
+
+  toBeTruthy(): void {
+    this.assert(!!this.actual, `Expected truthy, but received ${fmt(this.actual)}`);
+  }
+
+  toBeFalsy(): void {
+    this.assert(!this.actual, `Expected falsy, but received ${fmt(this.actual)}`);
+  }
+
+  toBeGreaterThan(expected: number): void {
+    this.assert((this.actual as number) > expected, `Expected ${fmt(this.actual)} > ${expected}`);
+  }
+
+  toBeLessThan(expected: number): void {
+    this.assert((this.actual as number) < expected, `Expected ${fmt(this.actual)} < ${expected}`);
+  }
+
+  toBeCloseTo(expected: number, precision = 2): void {
+    const tolerance = Math.pow(10, -precision) / 2;
+    const pass = Math.abs((this.actual as number) - expected) < tolerance;
+    this.assert(pass, `Expected ${fmt(this.actual)} to be close to ${expected} (precision ${precision})`);
+  }
+
+  toContain(expected: unknown): void {
+    const actual = this.actual as any;
+    const pass = Array.isArray(actual)
+      ? actual.includes(expected)
+      : typeof actual === 'string' ? actual.includes(expected as string) : false;
+    this.assert(pass, `Expected ${fmt(this.actual)} to contain ${fmt(expected)}`);
+  }
+
+  toBeNull(): void {
+    this.assert(this.actual === null, `Expected null, but received ${fmt(this.actual)}`);
+  }
+
+  toBeUndefined(): void {
+    this.assert(this.actual === undefined, `Expected undefined, but received ${fmt(this.actual)}`);
+  }
+
+  private assert(pass: boolean, message: string): void {
+    const ok = this.negated ? !pass : pass;
+    if (!ok) {
+      throw new ExpectError(this.negated ? `Negation failed: ${message}` : message);
+    }
+  }
+}
+
+function fmt(value: unknown): string {
+  return typeof value === 'string' ? `"${value}"` : String(value);
 }
 
 export class ExpectError extends Error {


### PR DESCRIPTION
expect() now detects whether it receives a Locator or a plain value. 

Locators use LocatorAssertions (existing behavior). 

Plain values get ValueAssertions with toBe, toEqual, toBeTruthy, toBeFalsy, toBeGreaterThan, toBeLessThan, toBeCloseTo, toContain, toBeNull, toBeUndefined, and .not negation.