### PR TITLE
fix(drivers): map UI dump `text` into ViewNode.text for locators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -960,6 +960,18 @@
       "resolved": "packages/test",
       "link": true
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -1090,9 +1102,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -1105,9 +1117,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -1116,9 +1128,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -1172,9 +1185,9 @@
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -1297,9 +1310,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -1401,7 +1414,7 @@
       "dependencies": {
         "@mobilewright/protocol": "^0.0.1",
         "debug": "^4.4.3",
-        "fast-xml-parser": "^5.0.0",
+        "fast-xml-parser": "^5.7.0",
         "mobilecli": "0.3.66",
         "ws": "^8.18.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -960,18 +960,6 @@
       "resolved": "packages/test",
       "link": true
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -1101,42 +1089,6 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1166,9 +1118,9 @@
       }
     },
     "node_modules/mobilecli": {
-      "version": "0.3.66",
-      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-0.3.66.tgz",
-      "integrity": "sha512-yC36WdpJsJAjznpCb2aYPqq7gEVG82ExY0JYSSeN9YhTHNgOrfAc09fHpTuKj6erSRJVBt/s48/vPDLvYUXN5A==",
+      "version": "0.3.67",
+      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-0.3.67.tgz",
+      "integrity": "sha512-XJIAYMADlLFmVp8JI/9NJDDTuAFENipuMo0Zt8HdCf6vLLaoG9dG9ebxkc2xV8Y1buNeyd4DsyVw91xI3O01SQ==",
       "license": "MIT",
       "bin": {
         "mobilecli": "index.js"
@@ -1183,21 +1135,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/playwright": {
       "version": "1.58.2",
@@ -1309,18 +1246,6 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1414,8 +1339,7 @@
       "dependencies": {
         "@mobilewright/protocol": "^0.0.1",
         "debug": "^4.4.3",
-        "fast-xml-parser": "^5.7.0",
-        "mobilecli": "0.3.66",
+        "mobilecli": "0.3.67",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -1436,6 +1360,7 @@
         "@mobilewright/protocol": "^0.0.1",
         "@mobilewright/test": "^0.0.1",
         "commander": "^14.0.3",
+        "debug": "^4.4.3",
         "playwright": "1.58.2",
         "ws": "^8.18.0"
       },
@@ -1476,7 +1401,8 @@
       "dependencies": {
         "@mobilewright/core": "^0.0.1",
         "@mobilewright/protocol": "^0.0.1",
-        "@playwright/test": "1.58.2"
+        "@playwright/test": "1.58.2",
+        "mobilewright": "^0.0.1"
       },
       "engines": {
         "node": ">=18"

--- a/packages/driver-mobile-use/src/driver.ts
+++ b/packages/driver-mobile-use/src/driver.ts
@@ -116,7 +116,7 @@ function elementToViewNode(el: MobileUseElement): ViewNode {
     label: el.label || undefined,
     identifier: el.identifier || el.name || undefined,
     value: el.value || undefined,
-    text: el.text || el.label || undefined,
+    text: el.text || undefined,
     isVisible: typeof el.visible === 'boolean' ? el.visible : bounds.width > 0 && bounds.height > 0,
     isEnabled: el.enabled ?? true,
     bounds,

--- a/packages/driver-mobile-use/src/driver.ts
+++ b/packages/driver-mobile-use/src/driver.ts
@@ -32,6 +32,7 @@ export const DEFAULT_URL = 'wss://api.mobilenexthq.com/ws';
 
 interface MobileUseElement {
   type: string;
+  text?: string;
   label?: string;
   name?: string;
   value?: string;
@@ -115,7 +116,7 @@ function elementToViewNode(el: MobileUseElement): ViewNode {
     label: el.label || undefined,
     identifier: el.identifier || el.name || undefined,
     value: el.value || undefined,
-    text: el.label || undefined,
+    text: el.text || el.label || undefined,
     isVisible: typeof el.visible === 'boolean' ? el.visible : bounds.width > 0 && bounds.height > 0,
     isEnabled: el.enabled ?? true,
     bounds,

--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -31,8 +31,7 @@
   "dependencies": {
     "@mobilewright/protocol": "^0.0.1",
     "debug": "^4.4.3",
-    "fast-xml-parser": "^5.7.0",
-    "mobilecli": "0.3.66",
+    "mobilecli": "0.3.67",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@mobilewright/protocol": "^0.0.1",
     "debug": "^4.4.3",
-    "fast-xml-parser": "^5.0.0",
+    "fast-xml-parser": "^5.7.0",
     "mobilecli": "0.3.66",
     "ws": "^8.18.0"
   },

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -112,7 +112,7 @@ function elementToViewNode(el: MobilecliElement): ViewNode {
     label: el.label || undefined,
     identifier: el.identifier || el.name || undefined,
     value: el.value || undefined,
-    text: el.text || el.label || undefined,
+    text: el.text || undefined,
     isVisible: typeof el.visible === 'boolean' ? el.visible : bounds.width > 0 && bounds.height > 0,
     isEnabled: el.enabled ?? true,
     bounds,

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -32,6 +32,7 @@ export const DEFAULT_URL = 'ws://localhost:12000/ws';
 /** Element shape returned by mobilecli's device.dump.ui JSON response */
 interface MobilecliElement {
   type: string;
+  text?: string;
   label?: string;
   name?: string;
   value?: string;
@@ -111,7 +112,7 @@ function elementToViewNode(el: MobilecliElement): ViewNode {
     label: el.label || undefined,
     identifier: el.identifier || el.name || undefined,
     value: el.value || undefined,
-    text: el.label || undefined,
+    text: el.text || el.label || undefined,
     isVisible: typeof el.visible === 'boolean' ? el.visible : bounds.width > 0 && bounds.height > 0,
     isEnabled: el.enabled ?? true,
     bounds,


### PR DESCRIPTION
1. Mobilecli and Mobile Use RPC elements can carry visible copy in `text`
and accessibility in `label`. ViewNode.text was only set from `label`,
so getByText / getByRole name matching missed Android TextView-style
nodes with empty labels. Prefer el.text then el.label.

2. Addresses GHSA-gh4j-gqv2-49f6; clears npm audit in CI.