### PR TITLE
fix(driver): reject .ipa installs on iOS simulators with a clear error

### DIFF
--- a/packages/driver-mobilecli/src/driver.test.ts
+++ b/packages/driver-mobilecli/src/driver.test.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import { MobilecliDriver } from './driver.js';
+
+const SIMULATOR_DEVICE_ID = 'sim-iphone-15';
+const SIMULATOR_DEVICE_NAME = 'iPhone 15';
+
+/**
+ * Patch a MobilecliDriver instance so it has a pre-established session and
+ * its `listDevices` call returns a controlled list — no real mobilecli binary
+ * or WebSocket server needed.
+ */
+function createDriverWithSimulatorSession(opts?: {
+  platform?: 'ios' | 'android';
+  deviceType?: 'simulator' | 'real';
+}): MobilecliDriver {
+  const platform = opts?.platform ?? 'ios';
+  const deviceType = opts?.deviceType ?? 'simulator';
+
+  const driver = new MobilecliDriver();
+
+  // Inject a fake active session directly into the private field.
+  (driver as any).session = {
+    deviceId: SIMULATOR_DEVICE_ID,
+    platform,
+    rpc: {
+      call: async () => {
+        throw new Error('RPC call should not have been made');
+      },
+      disconnect: async () => {},
+    },
+  };
+
+  // Stub listDevices to return the simulated device list.
+  driver.listDevices = async () => [
+    {
+      id: SIMULATOR_DEVICE_ID,
+      name: SIMULATOR_DEVICE_NAME,
+      platform,
+      type: deviceType,
+      state: 'online',
+    },
+  ];
+
+  return driver;
+}
+
+test.describe('MobilecliDriver.installApp()', () => {
+  test('throws a clear error when installing a .ipa on an iOS simulator', async () => {
+    const driver = createDriverWithSimulatorSession();
+
+    await expect(
+      driver.installApp('/path/to/MyApp.ipa'),
+    ).rejects.toThrow(
+      `Cannot install a .ipa file on iOS simulator "${SIMULATOR_DEVICE_NAME}".`,
+    );
+  });
+
+  test('error message contains instructions for building a .zip', async () => {
+    const driver = createDriverWithSimulatorSession();
+
+    let caughtError: Error | undefined;
+    try {
+      await driver.installApp('/path/to/MyApp.ipa');
+    } catch (err) {
+      caughtError = err as Error;
+    }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError!.message).toContain('xcodebuild');
+    expect(caughtError!.message).toContain('zip -r MyApp.zip MyApp.app');
+    expect(caughtError!.message).toContain('installApps config');
+  });
+
+  test('does not throw for a .ipa path when the device is a real iOS device (no RPC guard needed)', async () => {
+    const driver = createDriverWithSimulatorSession({ deviceType: 'real' });
+
+    // The RPC stub throws if called — but we expect it to be called here
+    // (real device allows .ipa). So swap the stub out to a no-op.
+    (driver as any).session.rpc.call = async () => ({});
+
+    await expect(driver.installApp('/path/to/MyApp.ipa')).resolves.toBeUndefined();
+  });
+
+  test('does not throw for a .zip path on an iOS simulator', async () => {
+    const driver = createDriverWithSimulatorSession();
+
+    // .zip path — guard must not fire; RPC will be called.
+    (driver as any).session.rpc.call = async () => ({});
+
+    await expect(driver.installApp('/path/to/MyApp.zip')).resolves.toBeUndefined();
+  });
+
+  test('does not throw for a .apk path (Android) even on a simulator-type device', async () => {
+    const driver = createDriverWithSimulatorSession({
+      platform: 'android',
+      deviceType: 'simulator',
+    });
+
+    (driver as any).session.rpc.call = async () => ({});
+
+    await expect(driver.installApp('/path/to/app.apk')).resolves.toBeUndefined();
+  });
+
+  test('is case-insensitive for the .IPA extension', async () => {
+    const driver = createDriverWithSimulatorSession();
+
+    await expect(
+      driver.installApp('/path/to/MyApp.IPA'),
+    ).rejects.toThrow(
+      `Cannot install a .ipa file on iOS simulator "${SIMULATOR_DEVICE_NAME}".`,
+    );
+  });
+
+  test('does not make an RPC call when the guard fires', async () => {
+    const driver = createDriverWithSimulatorSession();
+
+    // The injected RPC stub already throws — confirm installApp rejects with
+    // OUR error message, not the stub's "should not have been made" message.
+    let errorMessage = '';
+    try {
+      await driver.installApp('/path/to/app.ipa');
+    } catch (err) {
+      errorMessage = (err as Error).message;
+    }
+
+    expect(errorMessage).toContain('Cannot install a .ipa file on iOS simulator');
+    expect(errorMessage).not.toContain('RPC call should not have been made');
+  });
+});

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -384,6 +384,25 @@ export class MobilecliDriver implements MobilewrightDriver {
   }
 
   async installApp(path: string): Promise<void> {
+    if (/\.ipa$/i.test(path)) {
+      const session = this.requireSession();
+      if (session.platform === 'ios') {
+        const devices = await this.listDevices();
+        const device = devices.find((d) => d.id === session.deviceId);
+        if (device?.type === 'simulator') {
+          throw new Error(
+            `Cannot install a .ipa file on iOS simulator "${device.name}".\n\n` +
+            `iOS simulators require a .zip of the .app bundle. Build and package it with:\n\n` +
+            `  xcodebuild -scheme <Scheme> -configuration Debug \\\n` +
+            `    -destination "platform=iOS Simulator,name=${device.name}" \\\n` +
+            `    -derivedDataPath build build\n` +
+            `  cd build/Build/Products/Debug-iphonesimulator\n` +
+            `  zip -r MyApp.zip MyApp.app\n\n` +
+            `Then update your installApps config to point to MyApp.zip.`,
+          );
+        }
+      }
+    }
     await this.call('device.apps.install', { path });
   }
 


### PR DESCRIPTION
## Summary

- **Bug**: `device.installApp()` silently accepted a `.ipa` path when the target was an iOS simulator, then propagated a cryptic mobilecli platform error with no actionable guidance. This hit real users whose `installApps` config pointed to a device-only IPA archive.
- **Fix**: Added a proactive guard in `installApp()` — if the path ends in `.ipa` (case-insensitive) and the active session is an iOS simulator, throw immediately with a clear error message that names the simulator and includes step-by-step `xcodebuild` + `zip` instructions for producing a `.zip` of the `.app` bundle.
- **No behavior change** for real devices or non-`.ipa` paths (`.zip`, `.apk`, etc.).

## Test plan

- [ ] `packages/driver-mobilecli/src/driver.test.ts` — 7 new unit tests covering:
  - throws on `.ipa` targeting iOS simulator (happy-path guard)
  - error message contains `xcodebuild` and `zip` instructions
  - case-insensitive `.IPA` extension match
  - no throw for `.ipa` on a real iOS device
  - no throw for `.zip` on an iOS simulator
  - no throw for `.apk` on an Android emulator
  - no RPC call is made when the guard fires
- [ ] `npm test` passes (157 tests, 1 pre-existing skip)