### PR TITLE
feat(core): add waitForReady option to launchApp to avoid first-render flakiness

### DIFF
--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -84,7 +84,31 @@ program
       }
     }
 
-    const config = await loadConfigFromFile(configFile, overrides);
+    let config: Awaited<ReturnType<typeof loadConfigFromFile>>;
+    try {
+      config = await loadConfigFromFile(configFile, overrides);
+    } catch (err) {
+      if ((err as { code?: string }).code === 'ERR_REQUIRE_ESM') {
+        console.error(
+          [
+            '',
+            'Error: Could not load your mobilewright config.',
+            '',
+            'Your config file imports an ES Module (e.g. mobilewright), but your package.json',
+            'is missing "type": "module". Node\'s CommonJS loader cannot require() ES Modules.',
+            '',
+            'Fix: add the following to your package.json:',
+            '',
+            '  "type": "module"',
+            '',
+            'Then re-run: npx mobilewright test',
+            '',
+          ].join('\n'),
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
     const c = config as Record<string, unknown>;
     c.cliArgs = args;
     if (opts.grep) c.cliGrep = opts.grep;


### PR DESCRIPTION
## Problem

`launchApp()` resolves as soon as the OS acknowledges the launch. On cold start, the app hasn't rendered its first screen yet, causing the immediately-following assertion to fail. This is especially visible on first run after boot.

Observed in practice: a test checking for a welcome screen text timed out at 27 s on first run, then passed reliably (5–8 s) on subsequent warm runs. The `beforeEach` did `await device.launchApp(bundleId)` followed immediately by `await expect(screen.getByText('Welcome to Milliways')).toBeVisible()`.

## Fix

Opt-in `waitForReady` on `LaunchOptions` — polls `getViewHierarchy()` until ≥ 2 visible elements appear, up to a configurable timeout (default 5 s). Timeout is soft: if the app hasn't rendered by then, it resolves anyway and the first assertion produces the real error message.

## Usage

\`\`\`typescript
await device.launchApp('com.example.app', { waitForReady: true });
// or with a custom timeout:
await device.launchApp('com.example.app', { waitForReady: 10_000 });
\`\`\`

## Changes

- `packages/protocol/src/types.ts`: Added `waitForReady?: boolean | number` to `LaunchOptions`
- `packages/mobilewright-core/src/device.ts`: Implemented `pollUntilReady` private method; `launchApp` now calls it when `waitForReady` is set
- `packages/mobilewright-core/src/device.test.ts`: New test file covering the polling behaviour, soft timeout, error resilience, and the no-op path when `waitForReady` is not set

## Test plan

- [ ] `waitForReady: true` polls `getViewHierarchy()` at least once
- [ ] Resolves when ≥ 2 visible elements appear in hierarchy
- [ ] Resolves immediately when hierarchy is already ready
- [ ] Accepts a custom millisecond timeout (`waitForReady: 10_000`)
- [ ] Soft-timeout: resolves without throwing when app never becomes ready
- [ ] Continues polling (doesn't crash) when `getViewHierarchy` throws during early startup
- [ ] Does not poll at all when `waitForReady` is not set