### PR TITLE
fix(cli): show actionable error when package.json is missing "type": "module"

### DIFF
--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -84,7 +84,31 @@ program
       }
     }
 
-    const config = await loadConfigFromFile(configFile, overrides);
+    let config: Awaited<ReturnType<typeof loadConfigFromFile>>;
+    try {
+      config = await loadConfigFromFile(configFile, overrides);
+    } catch (err) {
+      if ((err as { code?: string }).code === 'ERR_REQUIRE_ESM') {
+        console.error(
+          [
+            '',
+            'Error: Could not load your mobilewright config.',
+            '',
+            'Your config file imports an ES Module (e.g. mobilewright), but your package.json',
+            'is missing "type": "module". Node\'s CommonJS loader cannot require() ES Modules.',
+            '',
+            'Fix: add the following to your package.json:',
+            '',
+            '  "type": "module"',
+            '',
+            'Then re-run: npx mobilewright test',
+            '',
+          ].join('\n'),
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
     const c = config as Record<string, unknown>;
     c.cliArgs = args;
     if (opts.grep) c.cliGrep = opts.grep;


### PR DESCRIPTION
## Summary

- **Bug:** running `mobilewright test` with a CJS `package.json` (missing `"type": "module"`) dumps a raw Node.js `ERR_REQUIRE_ESM` stack trace with no hint about the fix.
- **Fix:** catch `ERR_REQUIRE_ESM` in the config-loading step and print a clear message telling the user exactly what to add to their `package.json`.
- **Affects:** any user who scaffolds a new project without `"type": "module"` or copies config from a CJS project.

## Error before this fix

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../node_modules/mobilewright/dist/index.js
from .../mobilewright.config.ts not supported.
Instead change the require of index.js in .../mobilewright.config.ts to a dynamic import()
which is available in all CommonJS modules.
    at Object.newLoader2 [as .js] (.../playwright/lib/third_party/pirates.js:52:22)
    ...
```

## Error after this fix

```
Error: Could not load your mobilewright config.

Your config file imports an ES Module (e.g. mobilewright), but your package.json
is missing "type": "module". Node's CommonJS loader cannot require() ES Modules.

Fix: add the following to your package.json:

  "type": "module"

Then re-run: npx mobilewright test
```

## Test plan

- [ ] Verify existing tests pass (`npm test` — 147 passed, 1 skipped)
- [ ] Manually test with a project missing `"type": "module"` to confirm the friendly error is shown
- [ ] Verify that non-`ERR_REQUIRE_ESM` errors are still re-thrown as before