### PR TITLE
fix: use package.json version in CLI instead of hardcoded '0.0.1'

### DIFF
--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -23,7 +23,7 @@ const TEMPLATES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'te
 
 const program = new Command();
 program.name('mobilewright');
-program.version('0.0.1');
+program.version(_pkg.version);
 
 // ── test ───────────────────────────────────────────────────────────────
 program


### PR DESCRIPTION
## Summary
- `program.version('0.0.1')` was hardcoded in `cli.ts` despite `_pkg.version` already being imported from `package.json` on the line above
- Changed to `program.version(_pkg.version)` so `mobilewright --version` correctly reflects the published package version

## Test plan
- [ ] Run `mobilewright --version` after build — should output the version from `package.json`
