### PR TITLE
fix(android): warn and continue when foreground app check fails on launch

### DIFF
--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -84,12 +84,23 @@ export class Device {
     if (opts?.noWaitAfter) {
       return;
     }
-    await retryUntil(
-      () => this.getForegroundApp(),
-      (app) => app.bundleId === bundleId,
-      LAUNCH_APP_TIMEOUT,
-      `launchApp: timed out waiting for "${bundleId}" to be in foreground`,
-    );
+    try {
+      await retryUntil(
+        () => this.getForegroundApp(),
+        (app) => app.bundleId === bundleId,
+        LAUNCH_APP_TIMEOUT,
+        `launchApp: timed out waiting for "${bundleId}" to be in foreground`,
+      );
+    } catch (err) {
+      if (String(err).includes('could not determine foreground app')) {
+        // mobilecli's WebSocket RPC path for device.apps.foreground fails on
+        // some Android devices even though the app launched successfully.
+        // Warn and continue rather than failing the launch entirely.
+        console.warn(`[mobilewright] warning: could not verify "${bundleId}" reached foreground — proceeding anyway. This is a known mobilecli issue on some Android devices.`);
+        return;
+      }
+      throw err;
+    }
   }
 
   async terminateApp(bundleId: string): Promise<void> {


### PR DESCRIPTION
## Problem

On some Android devices (e.g. CMF Phone 2 Pro running Android 15), the mobilecli WebSocket RPC handler for `device.apps.foreground` returns `"could not determine foreground app"` immediately after `device.apps.launch`, even though the app launched successfully.

This causes `launchApp()` to throw, failing every test before it even starts:

```
RpcError: failed to get foreground app on device <id>: could not determine foreground app
```

## Root Cause

The CLI path (`mobilecli apps foreground --device <id>`) works correctly on the same device, pointing to a gap in the WebSocket RPC server implementation — not a permissions issue on the device.

## Fix

Catch the specific `"could not determine foreground app"` error in `launchApp()`, emit a `console.warn` so the issue is visible to the user, then return. Any other error is rethrown as before.

The underlying mobilecli server-side bug should still be fixed separately (likely in the [mobilecli](https://github.com/mobile-next/mobilecli) repo), but this makes mobilewright resilient to it in the meantime.

## Reproduction

1. Connect a CMF Phone 2 Pro (or similar Android 15 device)
2. Set `bundleId` in `mobilewright.config.ts`
3. Run `npx mobilewright test`
4. Observe the `could not determine foreground app` error on every test