### PR TITLE
feat(locator): add locator aliases and exists API

### DIFF
--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -109,11 +109,6 @@ export class Locator {
     await this.driver.tap(x, y);
   }
 
-  async click(
-    opts?: { timeout?: number }): Promise<void> {
-    return this.tap(opts);
-  }
-
   async doubleTap(opts?: { timeout?: number }): Promise<void> {
     const node = await this.resolveActionable(opts?.timeout);
     const { x, y } = centerOf(node.bounds);

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -109,6 +109,11 @@ export class Locator {
     await this.driver.tap(x, y);
   }
 
+  async click(
+    opts?: { timeout?: number }): Promise<void> {
+    return this.tap(opts);
+  }
+
   async doubleTap(opts?: { timeout?: number }): Promise<void> {
     const node = await this.resolveActionable(opts?.timeout);
     const { x, y } = centerOf(node.bounds);
@@ -168,6 +173,11 @@ export class Locator {
 
   // ─── Queries (with auto-wait for visibility) ─────────────────
 
+  async exists(): Promise<boolean> {
+    const node = await this.resolve(0);
+    return node !== null;
+  }
+  
   async isVisible(opts?: { timeout?: number }): Promise<boolean> {
     try {
       await this.waitFor({ state: 'visible', timeout: opts?.timeout ?? 0 });


### PR DESCRIPTION
This PR adds two small but useful Locator APIs to improve developer experience

Added APIs
locator.click()

Playwright-style alias for:

locator.tap()

Example:

await locator.click()
locator.exists()

**Notes:
No breaking changes
Existing APIs remain untouched
click() internally uses the existing tap() implementation
exists() uses the existing locator resolution flow**