### PR TITLE
fix: respect autoAppLaunch config option in test fixture

### DIFF
--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -31,6 +31,7 @@ async function attachVideo(testInfo: TestInfo, url: string | undefined, localPat
 type MobilewrightTestFixtures = {
   screen: Screen;
   bundleId: string | undefined;
+  autoAppLaunch: boolean | undefined;
   platform: 'ios' | 'android' | undefined;
   deviceName: RegExp | undefined;
   device: Device;
@@ -50,10 +51,15 @@ export const test = base.extend<MobilewrightTestFixtures>({
     await use(config.bundleId);
   }, { option: true }],
 
+  autoAppLaunch: [async ({}, use, testInfo) => {
+    const config = await loadConfig(process.cwd(), testInfo.config.configFile);
+    await use(config.autoAppLaunch);
+  }, { option: true }],
+
   platform: [undefined, { option: true }],
   deviceName: [undefined, { option: true }],
 
-  device: async ({ platform, deviceName, bundleId }, use, testInfo) => {
+  device: async ({ platform, deviceName, bundleId, autoAppLaunch }, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
     const merged = {
       ...config,
@@ -88,7 +94,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
         }
       }
 
-      if (bundleId) {
+      if (bundleId && autoAppLaunch !== false) {
         try {
           await device.terminateApp(bundleId);
         } catch {


### PR DESCRIPTION
## Problem

`autoAppLaunch: false` in `mobilewright.config` was silently ignored by the `@mobilewright/test` fixture. Even with the option set, the fixture always called `terminateApp` + `launchApp` before every test whenever `bundleId` was configured.

The option was only respected in the launcher path (`installAndLaunchApps`), not in the test fixture.

## Fix

- Added `autoAppLaunch` as a proper fixture option (reads from config, overridable per-test — consistent with how `bundleId` works)
- Threaded it into the `device` fixture
- Guarded the terminate/launch block: the app is only relaunched when `autoAppLaunch !== false`

## Behaviour

| Config | Before | After |
|--------|--------|-------|
| `bundleId` set, no `autoAppLaunch` | relaunches app (default) | relaunches app (default) ✓ |
| `bundleId` set, `autoAppLaunch: true` | relaunches app | relaunches app ✓ |
| `bundleId` set, `autoAppLaunch: false` | relaunches app ✗ | skips relaunch ✓ |

## Use case

Useful for development workflows and test suites where the app is already in the foreground and a cold restart is undesirable (e.g. preserving session state, faster iteration).

```ts
// mobilewright.config.ts
export default defineConfig({
  platform: 'android',
  bundleId: 'com.example.app',
  autoAppLaunch: false, // now actually works
});
```