### PR TITLE
feat(test): attach accessibility tree on test failure via saveTreeOnFailure

### DIFF
--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -69,8 +69,8 @@ export interface MobilewrightConfig {
   installApps?: string | string[];
   /** Automatically launch the app after connecting. Default: true. */
   autoAppLaunch?: boolean;
-  /** Attach the accessibility tree as JSON to the test report on failure. Default: false. */
-  saveTreeOnFailure?: boolean;
+  /** Attach the accessibility tree as JSON to the test report. 'on-failure' attaches on test failure, 'off' disables. Default: 'off'. */
+  viewTree?: 'on-failure' | 'off';
   /** mobilecli server URL (use for remote servers). */
   url?: string;
   /** Path to mobilecli binary (if not on PATH). */

--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -69,6 +69,8 @@ export interface MobilewrightConfig {
   installApps?: string | string[];
   /** Automatically launch the app after connecting. Default: true. */
   autoAppLaunch?: boolean;
+  /** Attach the accessibility tree as JSON to the test report on failure. Default: false. */
+  saveTreeOnFailure?: boolean;
   /** mobilecli server URL (use for remote servers). */
   url?: string;
   /** Path to mobilecli binary (if not on PATH). */

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -33,6 +33,7 @@ type MobilewrightTestFixtures = {
   bundleId: string | undefined;
   platform: 'ios' | 'android' | undefined;
   deviceName: RegExp | undefined;
+  saveTreeOnFailure: boolean;
   device: Device;
 };
 
@@ -52,6 +53,11 @@ export const test = base.extend<MobilewrightTestFixtures>({
 
   platform: [undefined, { option: true }],
   deviceName: [undefined, { option: true }],
+
+  saveTreeOnFailure: [async ({}, use, testInfo) => {
+    const config = await loadConfig(process.cwd(), testInfo.config.configFile);
+    await use(config.saveTreeOnFailure ?? false);
+  }, { option: true }],
 
   device: async ({ platform, deviceName, bundleId }, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
@@ -104,7 +110,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
     }
   },
 
-  screen: async ({ device, video }, use, testInfo) => {
+  screen: async ({ device, video, saveTreeOnFailure }, use, testInfo) => {
     const videoMode = typeof video === 'object' ? video.mode : video;
     const shouldRecord = videoMode === 'on' || videoMode === 'retain-on-failure';
     const videoPath = shouldRecord
@@ -144,6 +150,17 @@ export const test = base.extend<MobilewrightTestFixtures>({
         await testInfo.attach('screenshot-on-failure', { body: screenshot, contentType: 'image/png' });
       } catch {
         // device may be disconnected
+      }
+      if (saveTreeOnFailure) {
+        try {
+          const tree = await device.screen.viewTree();
+          await testInfo.attach('view-tree-on-failure', {
+            body: Buffer.from(JSON.stringify(tree, null, 2)),
+            contentType: 'application/json',
+          });
+        } catch {
+          // device may be disconnected
+        }
       }
     }
   },

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -33,7 +33,7 @@ type MobilewrightTestFixtures = {
   bundleId: string | undefined;
   platform: 'ios' | 'android' | undefined;
   deviceName: RegExp | undefined;
-  saveTreeOnFailure: boolean;
+  viewTree: 'on-failure' | 'off';
   device: Device;
 };
 
@@ -54,9 +54,13 @@ export const test = base.extend<MobilewrightTestFixtures>({
   platform: [undefined, { option: true }],
   deviceName: [undefined, { option: true }],
 
-  saveTreeOnFailure: [async ({}, use, testInfo) => {
+  viewTree: [async ({}, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
-    await use(config.saveTreeOnFailure ?? false);
+    const value = config.viewTree ?? 'off';
+    if (value !== 'on-failure' && value !== 'off') {
+      throw new Error(`Invalid viewTree value: "${value}". Must be "on-failure" or "off".`);
+    }
+    await use(value);
   }, { option: true }],
 
   device: async ({ platform, deviceName, bundleId }, use, testInfo) => {
@@ -110,7 +114,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
     }
   },
 
-  screen: async ({ device, video, saveTreeOnFailure }, use, testInfo) => {
+  screen: async ({ device, video, viewTree }, use, testInfo) => {
     const videoMode = typeof video === 'object' ? video.mode : video;
     const shouldRecord = videoMode === 'on' || videoMode === 'retain-on-failure';
     const videoPath = shouldRecord
@@ -151,7 +155,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
       } catch {
         // device may be disconnected
       }
-      if (saveTreeOnFailure) {
+      if (viewTree === 'on-failure') {
         try {
           const tree = await device.screen.viewTree();
           await testInfo.attach('view-tree-on-failure', {


### PR DESCRIPTION
## Motivation

When a test fails, the screenshot tells you *what* the screen looks like, but not *why* the locator didn't match. The accessibility tree has that answer — element labels, types, visibility flags, and bounds — but there's currently no way to capture it automatically on failure.

## What changed

- Added `saveTreeOnFailure?: boolean` to `MobilewrightConfig` in `packages/mobilewright/src/config.ts`
- Added a `saveTreeOnFailure` fixture option in `@mobilewright/test` (same pattern as `autoAppLaunch`) that reads the value from config, defaulting to `false`
- When a test fails and `saveTreeOnFailure: true`, the `screen` fixture calls `viewTree()` and attaches the result as `view-tree-on-failure` (application/json) to the test report — visible alongside the screenshot in the HTML report

The feature is opt-in and off by default, so existing projects are unaffected.

## Usage

```js
// mobilewright.config.js
module.exports = defineConfig({
  saveTreeOnFailure: true,
});
```

The `view-tree-on-failure` attachment appears in the HTML report under the failed test, containing the full `ViewNode[]` tree serialised as indented JSON.

## Test plan

- [ ] Run a passing test with `saveTreeOnFailure: true` — no attachment added
- [ ] Run a failing test with `saveTreeOnFailure: true` — `view-tree-on-failure` JSON attachment appears in the HTML report alongside the screenshot
- [ ] Run a failing test with `saveTreeOnFailure: false` (default) — no JSON attachment, existing `screenshot-on-failure` still works normally
- [ ] Device disconnect mid-test — failure is reported cleanly, no crash from the viewTree call (covered by the inner try/catch)