### PR TITLE
feat(inspect): add --disable-animations flag to fix uiautomator dump on animated screens

### DIFF
--- a/packages/driver-mobile-use/src/driver.ts
+++ b/packages/driver-mobile-use/src/driver.ts
@@ -3,6 +3,7 @@ import { stat } from 'node:fs/promises';
 import { basename } from 'node:path';
 import createDebug from 'debug';
 import type {
+  AnimationScales,
   AppInfo,
   ConnectionConfig,
   DeviceInfo,
@@ -397,6 +398,18 @@ export class MobileUseDriver implements MobilewrightDriver {
       debug('download screen recording from %s', result.url.split('?')[0]);
     }
     return result;
+  }
+
+  async getAnimationScales(): Promise<AnimationScales> {
+    return this.call<AnimationScales>('device.io.animation-scales.get');
+  }
+
+  async setAnimationScales(scales: AnimationScales): Promise<void> {
+    await this.call('device.io.animation-scales.set', {
+      window: scales.window,
+      transition: scales.transition,
+      animator: scales.animator,
+    });
   }
 
   // ─── Apps ───────────────────────────────────────────────────

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -1,6 +1,7 @@
 import createDebug from 'debug';
 import { execFileSync } from 'node:child_process';
 import type {
+  AnimationScales,
   AppInfo,
   ConnectionConfig,
   DeviceInfo,
@@ -335,6 +336,18 @@ export class MobilecliDriver implements MobilewrightDriver {
 
   async setOrientation(orientation: Orientation): Promise<void> {
     await this.call('device.io.orientation.set', { orientation });
+  }
+
+  async getAnimationScales(): Promise<AnimationScales> {
+    return this.call<AnimationScales>('device.io.animation-scales.get');
+  }
+
+  async setAnimationScales(scales: AnimationScales): Promise<void> {
+    await this.call('device.io.animation-scales.set', {
+      window: scales.window,
+      transition: scales.transition,
+      animator: scales.animator,
+    });
   }
 
   // ─── Recording Operations ─────────────────────────────────────

--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'node:child_process';
 import type {
+  AnimationScales,
   AppInfo,
   ConnectionConfig,
   LaunchOptions,
@@ -137,24 +137,19 @@ export class Device {
   // ─── Android animations ─────────────────────────────────────────
   // uiautomator dump fails on continuously animated screens (e.g. a
   // ride-searching page with a SurfaceView/TextureView animation that
-  // never settles). Disabling the three system animation scales via ADB
-  // before calling getViewHierarchy() lets the dump succeed.
+  // never settles). Disabling the three system animation scales before
+  // calling getViewHierarchy() lets the dump succeed.
+  //
+  // disableAnimations() saves and returns the current scales so the
+  // caller can restore the exact originals via enableAnimations(saved).
 
-  disableAnimations(): void {
-    const deviceId = (this.driver as { session?: { deviceId?: string } }).session?.deviceId;
-    this._setAnimationScales(deviceId, 0);
+  async disableAnimations(): Promise<AnimationScales> {
+    const saved = await this.driver.getAnimationScales();
+    await this.driver.setAnimationScales({ window: 0, transition: 0, animator: 0 });
+    return saved;
   }
 
-  enableAnimations(): void {
-    const deviceId = (this.driver as { session?: { deviceId?: string } }).session?.deviceId;
-    this._setAnimationScales(deviceId, 1);
-  }
-
-  private _setAnimationScales(deviceId: string | undefined, value: 0 | 1): void {
-    const prefix = deviceId ? ['-s', deviceId] : [];
-    const scales = ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'];
-    for (const scale of scales) {
-      execSync(['adb', ...prefix, 'shell', 'settings', 'put', 'global', scale, String(value)].join(' '));
-    }
+  async enableAnimations(scales: AnimationScales = { window: 1, transition: 1, animator: 1 }): Promise<void> {
+    await this.driver.setAnimationScales(scales);
   }
 }

--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import type {
   AppInfo,
   ConnectionConfig,
@@ -131,5 +132,29 @@ export class Device {
 
   async stopRecording(): Promise<RecordingResult> {
     return this.driver.stopRecording();
+  }
+
+  // ─── Android animations ─────────────────────────────────────────
+  // uiautomator dump fails on continuously animated screens (e.g. a
+  // ride-searching page with a SurfaceView/TextureView animation that
+  // never settles). Disabling the three system animation scales via ADB
+  // before calling getViewHierarchy() lets the dump succeed.
+
+  disableAnimations(): void {
+    const deviceId = (this.driver as { session?: { deviceId?: string } }).session?.deviceId;
+    this._setAnimationScales(deviceId, 0);
+  }
+
+  enableAnimations(): void {
+    const deviceId = (this.driver as { session?: { deviceId?: string } }).session?.deviceId;
+    this._setAnimationScales(deviceId, 1);
+  }
+
+  private _setAnimationScales(deviceId: string | undefined, value: 0 | 1): void {
+    const prefix = deviceId ? ['-s', deviceId] : [];
+    const scales = ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'];
+    for (const scale of scales) {
+      execSync(['adb', ...prefix, 'shell', 'settings', 'put', 'global', scale, String(value)].join(' '));
+    }
   }
 }

--- a/packages/mobilewright-core/src/expect.test.ts
+++ b/packages/mobilewright-core/src/expect.test.ts
@@ -84,6 +84,8 @@ function createMockDriver(hierarchy: ViewNode[]): MobilewrightDriver & { _tracke
     openUrl: async (...args: any[]) => { tracker.openUrlCalls.push(args); },
     startRecording: async () => {},
     stopRecording: async () => ({}),
+    getAnimationScales: async () => ({ window: 1, transition: 1, animator: 1 }),
+    setAnimationScales: async () => {},
   };
 }
 

--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -83,6 +83,8 @@ function createMockDriver(hierarchy: ViewNode[]): MobilewrightDriver & { _tracke
     openUrl: async (...args: any[]) => { tracker.openUrlCalls.push(args); },
     startRecording: async () => {},
     stopRecording: async () => ({}),
+    getAnimationScales: async () => ({ window: 1, transition: 1, animator: 1 }),
+    setAnimationScales: async () => {},
   };
 }
 

--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -13,6 +13,7 @@ import { MobilecliDriver, DEFAULT_URL, resolveMobilecliBinary } from '@mobilewri
 import { ensureMobilecliReachable } from './server.js';
 import { loadConfig } from './config.js';
 import { gatherChecks, renderTerminal, renderJSON } from './commands/doctor.js';
+import { runInspect, type InspectOptions } from './commands/inspect.js';
 import { brandReport } from './reporter.js';
 import { telemetry } from './telemetry.js';
 
@@ -246,6 +247,17 @@ program
     } finally {
       if (serverProcess) await serverProcess.kill();
     }
+  });
+
+// ── inspect ───────────────────────────────────────────────────────
+program
+  .command('inspect')
+  .description('dump the live accessibility tree of a connected device')
+  .option('-d, --device <id>', 'device ID (run "mobilewright devices" to list)')
+  .option('--url <url>', 'mobilecli server URL', DEFAULT_URL)
+  .option('--json', 'output raw ViewNode[] JSON instead of the terminal tree')
+  .action(async (opts: InspectOptions) => {
+    await runInspect(opts);
   });
 
 // ── install ───────────────────────────────────────────────────────

--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -14,6 +14,7 @@ import { ensureMobilecliReachable } from './server.js';
 import { loadConfig } from './config.js';
 import { gatherChecks, renderTerminal, renderJSON } from './commands/doctor.js';
 import { runInspect, type InspectOptions } from './commands/inspect.js';
+import { runInspectUI } from './commands/inspect-ui.js';
 import { brandReport } from './reporter.js';
 import { telemetry } from './telemetry.js';
 
@@ -256,8 +257,13 @@ program
   .option('-d, --device <id>', 'device ID (run "mobilewright devices" to list)')
   .option('--url <url>', 'mobilecli server URL', DEFAULT_URL)
   .option('--json', 'output raw ViewNode[] JSON instead of the terminal tree')
-  .action(async (opts: InspectOptions) => {
-    await runInspect(opts);
+  .option('--ui', 'open an interactive browser UI with auto-refresh and locator copy')
+  .action(async (opts: InspectOptions & { ui?: boolean }) => {
+    if (opts.ui) {
+      await runInspectUI(opts);
+    } else {
+      await runInspect(opts);
+    }
   });
 
 // ── install ───────────────────────────────────────────────────────

--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -258,6 +258,7 @@ program
   .option('--url <url>', 'mobilecli server URL', DEFAULT_URL)
   .option('--json', 'output raw ViewNode[] JSON instead of the terminal tree')
   .option('--ui', 'open an interactive browser UI with auto-refresh and locator copy')
+  .option('--disable-animations', 'disable Android system animations before dumping (fixes uiautomator failures on animated screens)')
   .action(async (opts: InspectOptions & { ui?: boolean }) => {
     if (opts.ui) {
       await runInspectUI(opts);

--- a/packages/mobilewright/src/commands/inspect-ui.ts
+++ b/packages/mobilewright/src/commands/inspect-ui.ts
@@ -9,24 +9,15 @@
  * Usage: npx mobilewright inspect --ui
  */
 import { createServer } from 'node:http';
-import { exec, execSync } from 'node:child_process';
+import { exec } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
+import type { AnimationScales } from '@mobilewright/protocol';
 import type { MobilewrightConfig } from '../config.js';
 import { ensureMobilecliReachable } from '../server.js';
 import { loadConfig } from '../config.js';
 
 const PORT = 9325;
-
-// ─── Animation helpers ────────────────────────────────────────────────────────
-
-const ANIMATION_SCALES = ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'] as const;
-
-function setAnimations(deviceId: string, value: 0 | 1): void {
-  for (const scale of ANIMATION_SCALES) {
-    execSync(`adb -s ${deviceId} shell settings put global ${scale} ${value}`);
-  }
-}
 
 export interface InspectUIOptions {
   device?: string;
@@ -416,8 +407,13 @@ export async function runInspectUI(opts: InspectUIOptions): Promise<void> {
   const driver = new MobilecliDriver({ url });
   const deviceId = await resolveDeviceId(opts.device, driver, config);
 
+  let savedScales: AnimationScales | undefined;
   if (opts.disableAnimations) {
-    setAnimations(deviceId, 0);
+    const tmpDriver = new MobilecliDriver({ url });
+    await tmpDriver.connect({ platform, deviceId, url });
+    savedScales = await tmpDriver.getAnimationScales();
+    await tmpDriver.setAnimationScales({ window: 0, transition: 0, animator: 0 });
+    await tmpDriver.disconnect();
     console.log('Android animations disabled.');
   }
 
@@ -449,9 +445,16 @@ export async function runInspectUI(opts: InspectUIOptions): Promise<void> {
   process.on('SIGINT', async () => {
     httpServer.close();
     await conn.disconnect();
-    if (opts.disableAnimations) {
-      setAnimations(deviceId, 1);
-      console.log('\nAndroid animations restored.');
+    if (savedScales) {
+      try {
+        const tmpDriver = new MobilecliDriver({ url });
+        await tmpDriver.connect({ platform, deviceId, url });
+        await tmpDriver.setAnimationScales(savedScales);
+        await tmpDriver.disconnect();
+        console.log('\nAndroid animations restored.');
+      } catch {
+        // best-effort restore
+      }
     }
     if (serverProcess) await serverProcess.kill();
     process.exit(0);

--- a/packages/mobilewright/src/commands/inspect-ui.ts
+++ b/packages/mobilewright/src/commands/inspect-ui.ts
@@ -9,7 +9,7 @@
  * Usage: npx mobilewright inspect --ui
  */
 import { createServer } from 'node:http';
-import { exec } from 'node:child_process';
+import { exec, execSync } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
 import type { MobilewrightConfig } from '../config.js';
@@ -18,9 +18,20 @@ import { loadConfig } from '../config.js';
 
 const PORT = 9325;
 
+// ─── Animation helpers ────────────────────────────────────────────────────────
+
+const ANIMATION_SCALES = ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'] as const;
+
+function setAnimations(deviceId: string, value: 0 | 1): void {
+  for (const scale of ANIMATION_SCALES) {
+    execSync(`adb -s ${deviceId} shell settings put global ${scale} ${value}`);
+  }
+}
+
 export interface InspectUIOptions {
   device?: string;
   url?: string;
+  disableAnimations?: boolean;
 }
 
 // ─── Device resolution ────────────────────────────────────────────────────────
@@ -404,6 +415,12 @@ export async function runInspectUI(opts: InspectUIOptions): Promise<void> {
 
   const driver = new MobilecliDriver({ url });
   const deviceId = await resolveDeviceId(opts.device, driver, config);
+
+  if (opts.disableAnimations) {
+    setAnimations(deviceId, 0);
+    console.log('Android animations disabled.');
+  }
+
   const conn = makeConnection(url, platform, deviceId);
 
   const httpServer = createServer(async (req, res) => {
@@ -432,6 +449,10 @@ export async function runInspectUI(opts: InspectUIOptions): Promise<void> {
   process.on('SIGINT', async () => {
     httpServer.close();
     await conn.disconnect();
+    if (opts.disableAnimations) {
+      setAnimations(deviceId, 1);
+      console.log('\nAndroid animations restored.');
+    }
     if (serverProcess) await serverProcess.kill();
     process.exit(0);
   });

--- a/packages/mobilewright/src/commands/inspect-ui.ts
+++ b/packages/mobilewright/src/commands/inspect-ui.ts
@@ -1,0 +1,438 @@
+/**
+ * mobilewright inspect --ui
+ *
+ * Serves an interactive browser UI that renders the live accessibility tree
+ * from a connected device. Supports manual refresh and auto-refresh with a
+ * configurable interval. Clicking a node shows its properties and ready-to-use
+ * locator suggestions with a one-click copy button.
+ *
+ * Usage: npx mobilewright inspect --ui
+ */
+import { createServer } from 'node:http';
+import { exec } from 'node:child_process';
+import { platform as osPlatform } from 'node:os';
+import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
+import type { MobilewrightConfig } from '../config.js';
+import { ensureMobilecliReachable } from '../server.js';
+import { loadConfig } from '../config.js';
+
+const PORT = 9325;
+
+export interface InspectUIOptions {
+  device?: string;
+  url?: string;
+}
+
+// ─── Device resolution ────────────────────────────────────────────────────────
+
+async function resolveDeviceId(
+  explicit: string | undefined,
+  driver: MobilecliDriver,
+  config: MobilewrightConfig,
+): Promise<string> {
+  if (explicit) return explicit;
+  if (config.deviceId) return config.deviceId;
+
+  const devices = await driver.listDevices();
+  const online = devices.filter(d => d.state === 'online');
+
+  if (online.length === 0) {
+    console.error("No online devices found. Specify one with --device <id>, or try 'mobilewright doctor'.");
+    process.exit(1);
+  }
+
+  if (config.deviceName) {
+    const pattern = config.deviceName instanceof RegExp
+      ? config.deviceName
+      : new RegExp(config.deviceName);
+    const matched = online.filter(d => pattern.test(d.name));
+    if (matched.length > 0) return matched[0].id;
+  }
+
+  if (online.length > 1) {
+    console.error('Multiple devices found. Specify one with --device <id>:');
+    for (const d of online) console.error(`  ${d.id}  ${d.name}`);
+    process.exit(1);
+  }
+
+  return online[0].id;
+}
+
+// ─── Persistent device connection ────────────────────────────────────────────
+
+function makeConnection(url: string, platform: 'ios' | 'android', deviceId: string) {
+  let driver: MobilecliDriver | null = null;
+  let connected = false;
+
+  async function ensureConnected(): Promise<void> {
+    if (!connected) {
+      driver = new MobilecliDriver({ url });
+      await driver.connect({ platform, deviceId, url });
+      connected = true;
+    }
+  }
+
+  async function getTree() {
+    try {
+      await ensureConnected();
+      return await driver!.getViewHierarchy();
+    } catch {
+      connected = false;
+      await ensureConnected();
+      return await driver!.getViewHierarchy();
+    }
+  }
+
+  async function disconnect(): Promise<void> {
+    if (driver && connected) {
+      await driver.disconnect().catch(() => {});
+      connected = false;
+    }
+  }
+
+  return { getTree, disconnect };
+}
+
+// ─── Browser open ─────────────────────────────────────────────────────────────
+
+function openBrowser(url: string): void {
+  const cmd = osPlatform() === 'win32' ? `start ${url}`
+    : osPlatform() === 'darwin'        ? `open ${url}`
+    : `xdg-open ${url}`;
+  exec(cmd);
+}
+
+// ─── HTML ─────────────────────────────────────────────────────────────────────
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>mobilewright inspect</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'SF Mono', 'Cascadia Code', Consolas, monospace;
+      font-size: 13px;
+      background: #1e1e2e;
+      color: #cdd6f4;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 16px;
+      background: #181825;
+      border-bottom: 1px solid #313244;
+      flex-shrink: 0;
+    }
+
+    .brand { font-weight: 600; color: #cba6f7; letter-spacing: 0.02em; }
+
+    .controls { display: flex; align-items: center; gap: 12px; }
+
+    .controls label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      color: #a6adc8;
+      user-select: none;
+    }
+
+    select, button {
+      background: #313244;
+      color: #cdd6f4;
+      border: 1px solid #45475a;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-family: inherit;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    button:hover, select:hover { background: #45475a; }
+    button:active { background: #585b70; }
+
+    #status { font-size: 11px; color: #585b70; min-width: 160px; text-align: right; }
+
+    main { display: flex; flex: 1; overflow: hidden; }
+
+    #tree-panel {
+      width: 55%;
+      overflow-y: auto;
+      border-right: 1px solid #313244;
+      padding: 8px 0;
+    }
+
+    #detail-panel { flex: 1; overflow-y: auto; padding: 16px; }
+
+    .node {
+      display: flex;
+      align-items: baseline;
+      padding: 3px 0;
+      cursor: pointer;
+      white-space: nowrap;
+      user-select: none;
+      border-radius: 3px;
+    }
+
+    .node:hover  { background: #2a2a3d; }
+    .node.active { background: #45475a; }
+
+    .arrow { display: inline-block; width: 16px; flex-shrink: 0; color: #585b70; text-align: center; }
+    .arrow.open { color: #a6adc8; }
+
+    .type { color: #89b4fa; }
+    .lbl  { color: #a6e3a1; }
+    .txt  { color: #f9e2af; }
+    .ph   { color: #585b70; }
+    .sep  { color: #45475a; margin: 0 5px; }
+    .vis  { color: #a6e3a1; font-size: 11px; }
+    .hid  { color: #585b70; font-size: 11px; }
+
+    .empty { color: #585b70; text-align: center; margin-top: 60px; line-height: 1.8; }
+
+    .detail-type {
+      font-size: 15px;
+      font-weight: 600;
+      color: #89b4fa;
+      margin-bottom: 14px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #313244;
+    }
+
+    table { width: 100%; border-collapse: collapse; margin-bottom: 18px; }
+    td { padding: 4px 0; vertical-align: top; }
+    td:first-child { color: #a6adc8; width: 110px; padding-right: 12px; white-space: nowrap; }
+
+    .section-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #45475a;
+      margin: 4px 0 8px;
+    }
+
+    .loc-row {
+      display: flex;
+      align-items: center;
+      background: #181825;
+      border: 1px solid #313244;
+      border-radius: 4px;
+      padding: 7px 10px;
+      margin-bottom: 6px;
+      gap: 10px;
+    }
+
+    .loc-code { color: #cba6f7; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .copy-btn { flex-shrink: 0; padding: 3px 10px; font-size: 11px; }
+    .copy-btn.ok { color: #a6e3a1; border-color: #a6e3a1; }
+  </style>
+</head>
+<body>
+  <header>
+    <span class="brand">mobilewright inspect</span>
+    <div class="controls">
+      <label><input type="checkbox" id="autoToggle"> Auto-refresh</label>
+      <select id="intervalSel">
+        <option value="1000">1s</option>
+        <option value="2000" selected>2s</option>
+        <option value="5000">5s</option>
+        <option value="10000">10s</option>
+      </select>
+      <button id="refreshBtn">Refresh</button>
+      <span id="status"></span>
+    </div>
+  </header>
+  <main>
+    <div id="tree-panel"></div>
+    <div id="detail-panel"><p class="empty">Click a node to inspect it</p></div>
+  </main>
+<script>
+  let tree = [], selectedPath = null;
+  const expanded = new Set();
+
+  async function fetchTree() {
+    setStatus('Refreshing…');
+    try {
+      const res = await fetch('/api/tree');
+      if (!res.ok) throw new Error(res.statusText);
+      tree = await res.json();
+      renderTree();
+      setStatus('Updated ' + new Date().toLocaleTimeString());
+    } catch (e) { setStatus('Error: ' + e.message); }
+  }
+
+  function setStatus(msg) { document.getElementById('status').textContent = msg; }
+
+  let timer = null;
+  document.getElementById('autoToggle').addEventListener('change', e => e.target.checked ? startAuto() : stopAuto());
+  document.getElementById('intervalSel').addEventListener('change', () => {
+    if (document.getElementById('autoToggle').checked) { stopAuto(); startAuto(); }
+  });
+  document.getElementById('refreshBtn').addEventListener('click', fetchTree);
+  function startAuto() { timer = setInterval(fetchTree, Number(document.getElementById('intervalSel').value)); }
+  function stopAuto()  { clearInterval(timer); timer = null; }
+
+  function renderTree() {
+    const panel = document.getElementById('tree-panel');
+    const frag = document.createDocumentFragment();
+    renderNodes(tree, frag, [], 0);
+    panel.replaceChildren(frag);
+    if (selectedPath) {
+      const el = panel.querySelector('[data-path="' + CSS.escape(selectedPath) + '"]');
+      if (el) el.classList.add('active');
+    }
+  }
+
+  function renderNodes(nodes, parent, pathParts, depth) {
+    nodes.forEach((node, i) => {
+      const path = [...pathParts, i].join('.');
+      const hasKids = node.children && node.children.length > 0;
+      const isOpen  = expanded.has(path);
+
+      const row = document.createElement('div');
+      row.className = 'node';
+      row.dataset.path = path;
+      row.style.paddingLeft = (depth * 16 + 8) + 'px';
+
+      const arrow = document.createElement('span');
+      arrow.className = 'arrow' + (isOpen ? ' open' : '');
+      arrow.textContent = hasKids ? (isOpen ? '▾' : '▸') : ' ';
+      row.appendChild(arrow);
+
+      const typeEl = document.createElement('span');
+      typeEl.className = 'type';
+      typeEl.textContent = node.type;
+      row.appendChild(typeEl);
+
+      const addProp = (cls, text) => { row.appendChild(sep()); const s = document.createElement('span'); s.className = cls; s.textContent = text; row.appendChild(s); };
+      if (node.label)                            addProp('lbl', 'label="' + node.label + '"');
+      if (node.text && node.text !== node.label) addProp('txt', '"' + node.text + '"');
+      if (node.placeholder)                      addProp('ph',  'placeholder="' + node.placeholder + '"');
+
+      row.appendChild(sep());
+      const visEl = document.createElement('span');
+      visEl.className = node.isVisible ? 'vis' : 'hid';
+      visEl.textContent = node.isVisible ? 'visible' : 'hidden';
+      row.appendChild(visEl);
+
+      row.addEventListener('click', e => {
+        if (e.target === arrow && hasKids) { isOpen ? expanded.delete(path) : expanded.add(path); renderTree(); return; }
+        selectedPath = path;
+        document.querySelectorAll('.node.active').forEach(n => n.classList.remove('active'));
+        row.classList.add('active');
+        renderDetail(node);
+      });
+
+      parent.appendChild(row);
+      if (hasKids && isOpen) renderNodes(node.children, parent, [...pathParts, i], depth + 1);
+    });
+  }
+
+  function sep() { const s = document.createElement('span'); s.className = 'sep'; s.textContent = '\xb7'; return s; }
+
+  function renderDetail(node) {
+    const panel = document.getElementById('detail-panel');
+    panel.innerHTML = '';
+
+    const h = document.createElement('div'); h.className = 'detail-type'; h.textContent = node.type; panel.appendChild(h);
+
+    const props = [
+      node.label       && ['label',       node.label],
+      node.text        && ['text',         node.text],
+      node.placeholder && ['placeholder', node.placeholder],
+      node.identifier  && ['identifier',  node.identifier],
+      node.resourceId  && ['resourceId',  node.resourceId],
+      ['visible', node.isVisible ? 'true' : 'false'],
+      ['enabled', node.isEnabled ? 'true' : 'false'],
+      node.isChecked !== undefined && ['checked', String(node.isChecked)],
+      node.bounds && ['bounds', 'x:' + node.bounds.x + ' y:' + node.bounds.y + ' ' + node.bounds.width + '\xd7' + node.bounds.height],
+    ].filter(Boolean);
+
+    const table = document.createElement('table');
+    props.forEach(([k, v]) => { const tr = table.insertRow(); tr.insertCell().textContent = k; tr.insertCell().textContent = v; });
+    panel.appendChild(table);
+
+    const locators = suggestLocators(node);
+    if (locators.length) {
+      const lbl = document.createElement('div'); lbl.className = 'section-label'; lbl.textContent = 'Locators'; panel.appendChild(lbl);
+      locators.forEach(code => {
+        const row = document.createElement('div'); row.className = 'loc-row';
+        const codeEl = document.createElement('span'); codeEl.className = 'loc-code'; codeEl.textContent = code;
+        const btn = document.createElement('button'); btn.className = 'copy-btn'; btn.textContent = 'Copy';
+        btn.addEventListener('click', () => navigator.clipboard.writeText(code).then(() => {
+          btn.textContent = 'Copied!'; btn.classList.add('ok');
+          setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('ok'); }, 1500);
+        }));
+        row.appendChild(codeEl); row.appendChild(btn); panel.appendChild(row);
+      });
+    }
+  }
+
+  function suggestLocators(node) {
+    const out = [];
+    if (node.label)       out.push('screen.getByLabel(' + JSON.stringify(node.label) + ')');
+    if (node.text)        out.push('screen.getByText(' + JSON.stringify(node.text) + ')');
+    if (node.placeholder) out.push('screen.getByPlaceholder(' + JSON.stringify(node.placeholder) + ')');
+    if (node.identifier)  out.push('screen.getByTestId(' + JSON.stringify(node.identifier) + ')');
+    if (node.resourceId)  out.push('screen.getByTestId(' + JSON.stringify(node.resourceId) + ')');
+    out.push('screen.getByType(' + JSON.stringify(node.type) + ')');
+    return out;
+  }
+
+  fetchTree();
+</script>
+</body>
+</html>`;
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+export async function runInspectUI(opts: InspectUIOptions): Promise<void> {
+  const config = await loadConfig();
+  const url = opts.url ?? DEFAULT_URL;
+  const platform = (config.platform ?? 'android') as 'ios' | 'android';
+
+  const { serverProcess } = await ensureMobilecliReachable(url, { autoStart: true });
+
+  const driver = new MobilecliDriver({ url });
+  const deviceId = await resolveDeviceId(opts.device, driver, config);
+  const conn = makeConnection(url, platform, deviceId);
+
+  const httpServer = createServer(async (req, res) => {
+    if (req.url === '/api/tree') {
+      try {
+        const tree = await conn.getTree();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(tree));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(HTML);
+    }
+  });
+
+  httpServer.listen(PORT, () => {
+    const inspectUrl = `http://localhost:${PORT}`;
+    console.log(`\nInspector running at ${inspectUrl}\n`);
+    console.log('Press Ctrl+C to stop.\n');
+    openBrowser(inspectUrl);
+  });
+
+  process.on('SIGINT', async () => {
+    httpServer.close();
+    await conn.disconnect();
+    if (serverProcess) await serverProcess.kill();
+    process.exit(0);
+  });
+}

--- a/packages/mobilewright/src/commands/inspect.ts
+++ b/packages/mobilewright/src/commands/inspect.ts
@@ -1,0 +1,132 @@
+/**
+ * mobilewright inspect
+ *
+ * Dumps the live accessibility tree from a connected device to the terminal.
+ * Useful for figuring out which locator to use when writing tests — run it
+ * with the app open on the screen you want to inspect.
+ *
+ * Pass --json to get raw ViewNode[] JSON suitable for piping to jq or saving
+ * to a file for diffing between two app states.
+ */
+import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
+import type { ViewNode } from '@mobilewright/protocol';
+import { ensureMobilecliReachable } from '../server.js';
+import { loadConfig } from '../config.js';
+
+// ─── ANSI helpers ─────────────────────────────────────────────────────────────
+
+const C = {
+  reset:  '\x1b[0m',
+  bold:   '\x1b[1m',
+  dim:    '\x1b[2m',
+  cyan:   '\x1b[36m',
+  green:  '\x1b[32m',
+  gray:   '\x1b[90m',
+  white:  '\x1b[97m',
+} as const;
+
+// ─── Tree renderer ────────────────────────────────────────────────────────────
+
+function renderNode(node: ViewNode, prefix: string, isLast: boolean): void {
+  const connector   = isLast ? '└── ' : '├── ';
+  const childPrefix = prefix + (isLast ? '    ' : '│   ');
+
+  let line = `${C.gray}${prefix}${connector}${C.reset}`;
+  line += `${C.cyan}${node.type}${C.reset}`;
+
+  if (node.label)                            line += `  ${C.white}label=${JSON.stringify(node.label)}${C.reset}`;
+  if (node.text && node.text !== node.label) line += `  ${C.white}"${node.text}"${C.reset}`;
+  if (node.placeholder)                      line += `  ${C.dim}placeholder=${JSON.stringify(node.placeholder)}${C.reset}`;
+  if (node.identifier)                       line += `  ${C.dim}id=${JSON.stringify(node.identifier)}${C.reset}`;
+
+  line += node.isVisible
+    ? `  ${C.green}[visible]${C.reset}`
+    : `  ${C.gray}[hidden]${C.reset}`;
+
+  process.stdout.write(line + '\n');
+
+  const children = node.children ?? [];
+  for (let i = 0; i < children.length; i++) {
+    renderNode(children[i], childPrefix, i === children.length - 1);
+  }
+}
+
+function renderTree(nodes: ViewNode[]): void {
+  for (let i = 0; i < nodes.length; i++) {
+    renderNode(nodes[i], '', i === nodes.length - 1);
+  }
+}
+
+function countNodes(nodes: ViewNode[]): number {
+  return nodes.reduce((acc, n) => acc + 1 + countNodes(n.children ?? []), 0);
+}
+
+// ─── Device resolution ────────────────────────────────────────────────────────
+
+async function resolveDeviceId(explicit: string | undefined, driver: MobilecliDriver): Promise<string> {
+  if (explicit) return explicit;
+
+  const config = await loadConfig();
+  if (config.deviceId) return config.deviceId;
+
+  const devices = await driver.listDevices();
+  const online = devices.filter(d => d.state === 'online');
+
+  if (online.length === 0) {
+    console.error('No online devices found. Specify one with --device <id>, or try \'mobilewright doctor\'.');
+    process.exit(1);
+  }
+
+  if (config.deviceName) {
+    const pattern = config.deviceName instanceof RegExp
+      ? config.deviceName
+      : new RegExp(config.deviceName);
+    const matched = online.filter(d => pattern.test(d.name));
+    if (matched.length > 0) return matched[0].id;
+  }
+
+  if (online.length > 1) {
+    console.error('Multiple devices found. Specify one with --device <id>:');
+    for (const d of online) console.error(`  ${d.id}  ${d.name}`);
+    process.exit(1);
+  }
+
+  return online[0].id;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+export interface InspectOptions {
+  device?: string;
+  url?: string;
+  json?: boolean;
+}
+
+export async function runInspect(opts: InspectOptions): Promise<void> {
+  const config = await loadConfig();
+  const url = opts.url ?? DEFAULT_URL;
+  const platform = config.platform ?? 'android';
+
+  const { serverProcess } = await ensureMobilecliReachable(url, { autoStart: true });
+  try {
+    const driver = new MobilecliDriver({ url });
+    const deviceId = await resolveDeviceId(opts.device, driver);
+
+    await driver.connect({ platform, deviceId, url });
+    const tree = await driver.getViewHierarchy();
+    await driver.disconnect();
+
+    if (opts.json) {
+      console.log(JSON.stringify(tree, null, 2));
+      return;
+    }
+
+    const total = countNodes(tree);
+    const label = config.deviceName?.toString().replace(/^\/|\/$/g, '') ?? deviceId;
+    console.log(`\n${C.bold}${label}${C.reset}  ${C.dim}${total} nodes${C.reset}\n`);
+    renderTree(tree);
+    console.log();
+  } finally {
+    if (serverProcess) await serverProcess.kill();
+  }
+}

--- a/packages/mobilewright/src/commands/inspect.ts
+++ b/packages/mobilewright/src/commands/inspect.ts
@@ -8,10 +8,21 @@
  * Pass --json to get raw ViewNode[] JSON suitable for piping to jq or saving
  * to a file for diffing between two app states.
  */
+import { execSync } from 'node:child_process';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
 import type { ViewNode } from '@mobilewright/protocol';
 import { ensureMobilecliReachable } from '../server.js';
 import { loadConfig } from '../config.js';
+
+// ─── Animation helpers ────────────────────────────────────────────────────────
+
+const ANIMATION_SCALES = ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'] as const;
+
+function setAnimations(deviceId: string, value: 0 | 1): void {
+  for (const scale of ANIMATION_SCALES) {
+    execSync(`adb -s ${deviceId} shell settings put global ${scale} ${value}`);
+  }
+}
 
 // ─── ANSI helpers ─────────────────────────────────────────────────────────────
 
@@ -100,6 +111,7 @@ export interface InspectOptions {
   device?: string;
   url?: string;
   json?: boolean;
+  disableAnimations?: boolean;
 }
 
 export async function runInspect(opts: InspectOptions): Promise<void> {
@@ -112,9 +124,20 @@ export async function runInspect(opts: InspectOptions): Promise<void> {
     const driver = new MobilecliDriver({ url });
     const deviceId = await resolveDeviceId(opts.device, driver);
 
+    if (opts.disableAnimations) {
+      setAnimations(deviceId, 0);
+    }
+
     await driver.connect({ platform, deviceId, url });
-    const tree = await driver.getViewHierarchy();
-    await driver.disconnect();
+    let tree: Awaited<ReturnType<typeof driver.getViewHierarchy>>;
+    try {
+      tree = await driver.getViewHierarchy();
+    } finally {
+      await driver.disconnect();
+      if (opts.disableAnimations) {
+        setAnimations(deviceId, 1);
+      }
+    }
 
     if (opts.json) {
       console.log(JSON.stringify(tree, null, 2));

--- a/packages/mobilewright/src/commands/inspect.ts
+++ b/packages/mobilewright/src/commands/inspect.ts
@@ -8,21 +8,10 @@
  * Pass --json to get raw ViewNode[] JSON suitable for piping to jq or saving
  * to a file for diffing between two app states.
  */
-import { execSync } from 'node:child_process';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
-import type { ViewNode } from '@mobilewright/protocol';
+import type { AnimationScales, ViewNode } from '@mobilewright/protocol';
 import { ensureMobilecliReachable } from '../server.js';
 import { loadConfig } from '../config.js';
-
-// ─── Animation helpers ────────────────────────────────────────────────────────
-
-const ANIMATION_SCALES = ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'] as const;
-
-function setAnimations(deviceId: string, value: 0 | 1): void {
-  for (const scale of ANIMATION_SCALES) {
-    execSync(`adb -s ${deviceId} shell settings put global ${scale} ${value}`);
-  }
-}
 
 // ─── ANSI helpers ─────────────────────────────────────────────────────────────
 
@@ -124,19 +113,20 @@ export async function runInspect(opts: InspectOptions): Promise<void> {
     const driver = new MobilecliDriver({ url });
     const deviceId = await resolveDeviceId(opts.device, driver);
 
-    if (opts.disableAnimations) {
-      setAnimations(deviceId, 0);
-    }
-
     await driver.connect({ platform, deviceId, url });
+    let savedScales: AnimationScales | undefined;
     let tree: Awaited<ReturnType<typeof driver.getViewHierarchy>>;
     try {
+      if (opts.disableAnimations) {
+        savedScales = await driver.getAnimationScales();
+        await driver.setAnimationScales({ window: 0, transition: 0, animator: 0 });
+      }
       tree = await driver.getViewHierarchy();
     } finally {
-      await driver.disconnect();
-      if (opts.disableAnimations) {
-        setAnimations(deviceId, 1);
+      if (savedScales) {
+        await driver.setAnimationScales(savedScales).catch(() => {});
       }
+      await driver.disconnect();
     }
 
     if (opts.json) {

--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -69,6 +69,8 @@ export interface MobilewrightConfig {
   installApps?: string | string[];
   /** Automatically launch the app after connecting. Default: true. */
   autoAppLaunch?: boolean;
+  /** Attach the accessibility tree as JSON to the test report on failure. Default: false. */
+  saveTreeOnFailure?: boolean;
   /** mobilecli server URL (use for remote servers). */
   url?: string;
   /** Path to mobilecli binary (if not on PATH). */

--- a/packages/protocol/src/driver.ts
+++ b/packages/protocol/src/driver.ts
@@ -1,4 +1,5 @@
 import type {
+  AnimationScales,
   AppInfo,
   ConnectionConfig,
   DeviceInfo,
@@ -39,6 +40,8 @@ export interface MobilewrightDriver {
   getScreenSize(): Promise<ScreenSize>;
   getOrientation(): Promise<Orientation>;
   setOrientation(orientation: Orientation): Promise<void>;
+  getAnimationScales(): Promise<AnimationScales>;
+  setAnimationScales(scales: AnimationScales): Promise<void>;
 
   // Apps
   launchApp(bundleId: string, opts?: LaunchOptions): Promise<void>;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -157,6 +157,16 @@ export interface RecordingOptions {
   timeLimit?: number;
 }
 
+// ─── Animation Scales ───────────────────────────────────────────
+// Android only. Controls the three global animation scale settings that
+// uiautomator uses to determine when a screen is stable enough to dump.
+
+export interface AnimationScales {
+  window: number;
+  transition: number;
+  animator: number;
+}
+
 export interface RecordingResult {
   /** Operation status */
   status?: string;

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -33,6 +33,7 @@ type MobilewrightTestFixtures = {
   bundleId: string | undefined;
   platform: 'ios' | 'android' | undefined;
   deviceName: RegExp | undefined;
+  saveTreeOnFailure: boolean;
   device: Device;
 };
 
@@ -52,6 +53,11 @@ export const test = base.extend<MobilewrightTestFixtures>({
 
   platform: [undefined, { option: true }],
   deviceName: [undefined, { option: true }],
+
+  saveTreeOnFailure: [async ({}, use, testInfo) => {
+    const config = await loadConfig(process.cwd(), testInfo.config.configFile);
+    await use(config.saveTreeOnFailure ?? false);
+  }, { option: true }],
 
   device: async ({ platform, deviceName, bundleId }, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
@@ -104,7 +110,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
     }
   },
 
-  screen: async ({ device, video }, use, testInfo) => {
+  screen: async ({ device, video, saveTreeOnFailure }, use, testInfo) => {
     const videoMode = typeof video === 'object' ? video.mode : video;
     const shouldRecord = videoMode === 'on' || videoMode === 'retain-on-failure';
     const videoPath = shouldRecord
@@ -144,6 +150,17 @@ export const test = base.extend<MobilewrightTestFixtures>({
         await testInfo.attach('screenshot-on-failure', { body: screenshot, contentType: 'image/png' });
       } catch {
         // device may be disconnected
+      }
+      if (saveTreeOnFailure) {
+        try {
+          const tree = await device.screen.viewTree();
+          await testInfo.attach('view-tree-on-failure', {
+            body: Buffer.from(JSON.stringify(tree, null, 2)),
+            contentType: 'application/json',
+          });
+        } catch {
+          // device may be disconnected
+        }
       }
     }
   },


### PR DESCRIPTION
## Problem

`npx mobilewright inspect` fails with:

```
RpcError: no XML content found in uiautomator dump
```

This happens on screens that are **continuously animated** — a ride-searching page with a `SurfaceView` or `TextureView` that never settles. uiautomator's XML dump requires a stable layout so it always fails on these screens.

## Solution

Adds `--disable-animations` to the `inspect` command and `disableAnimations()`  `enableAnimations()` to the `Device` class. These call two new RPC methods in mobilecli — `device.io.animation-scales.get` and `device.io.animation-scales.set` — to disable the three Android global animation scales before dumping and restore the **original** values afterward (GET first, so we never assume the scales were 1).

Animations are always restored — in a `finally` block for the terminal command, on `SIGINT` for the browser UI, and in a `finally` block in tests.

## Dependencies

> **Requires:** mobile-next/mobilecli#230 — adds `device.io.animation-scales.get/set` RPC methods to mobilecli (Android only). This PR should be merged after that one.
>
> **Depends on:** #113 (inspect --ui)

## Changes

- **`AnimationScales` type** added to `@mobilewright/protocol`
- **`getAnimationScales()`  `setAnimationScales()`** added to the `MobilewrightDriver` interface, implemented in `driver-mobilecli` and `driver-mobile-use`
- **`Device.disableAnimations()`** — saves current scales, sets all to 0, returns saved scales
- **`Device.enableAnimations(saved)`** — restores to the saved scales (defaults to 1 if none passed)
- **`--disable-animations` flag** on `inspect` (terminal tree dump)
- **`--disable-animations` flag** on `inspect --ui` (browser UI — disabled on start, restored on Ctrl+C)

## Usage

```bash
# terminal dump on an animated screen
npx mobilewright inspect --disable-animations

# browser UI on an animated screen
npx mobilewright inspect --ui --disable-animations
```

In tests:

```ts
test('ride searching screen', async ({ screen, device }) => {
  const saved = await device.disableAnimations();
  try {
    await expect(screen.getByText('Finding nearby')).toBeVisible();
  } finally {
    await device.enableAnimations(saved);
  }
});
```

## Tested

Built the mobilecli binary from mobile-next/mobilecli#230 locally, swapped it into `node_modules`, and confirmed `device.io.animation-scales.get/set` works end-to-end on a live Android device with a continuously animated ride-searching screen.