### PR TITLE
feat: add toHaveCount and toBeEmpty assertions

### DIFF
--- a/packages/mobilewright-core/src/expect.test.ts
+++ b/packages/mobilewright-core/src/expect.test.ts
@@ -375,6 +375,105 @@ test.describe('expect', () => {
     });
   });
 
+  test.describe('toHaveCount', () => {
+    const listTree: ViewNode[] = [
+      node({
+        type: 'Window',
+        children: [
+          node({ type: 'Cell', label: 'A', bounds: { x: 0, y: 0, width: 390, height: 44 } }),
+          node({ type: 'Cell', label: 'B', bounds: { x: 0, y: 44, width: 390, height: 44 } }),
+          node({ type: 'Cell', label: 'C', bounds: { x: 0, y: 88, width: 390, height: 44 } }),
+        ],
+      }),
+    ];
+
+    test('passes with correct count', async () => {
+      const driver = createMockDriver(listTree);
+      const locator = new Locator(driver, { kind: 'type', value: 'Cell' });
+      await mwExpect(locator).toHaveCount(3);
+    });
+
+    test('fails with wrong count', async () => {
+      const driver = createMockDriver(listTree);
+      const locator = new Locator(driver, { kind: 'type', value: 'Cell' });
+      await expect(mwExpect(locator).toHaveCount(5, { timeout: 200 })).rejects.toThrow(ExpectError);
+    });
+
+    test('not.toHaveCount passes when count differs', async () => {
+      const driver = createMockDriver(listTree);
+      const locator = new Locator(driver, { kind: 'type', value: 'Cell' });
+      await mwExpect(locator).not.toHaveCount(5);
+    });
+
+    test('passes with zero count', async () => {
+      const driver = createMockDriver(listTree);
+      const locator = new Locator(driver, { kind: 'type', value: 'Button' });
+      await mwExpect(locator).toHaveCount(0);
+    });
+  });
+
+  test.describe('toBeEmpty', () => {
+    test('passes when value is empty', async () => {
+      const emptyValueTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'TextField',
+              label: 'Search',
+              identifier: 'searchField',
+              value: '',
+              bounds: { x: 0, y: 0, width: 300, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(emptyValueTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'searchField' });
+      await mwExpect(locator).toBeEmpty();
+    });
+
+    test('fails when value is not empty', async () => {
+      const filledTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'TextField',
+              label: 'Search',
+              identifier: 'searchField',
+              value: 'hello',
+              bounds: { x: 0, y: 0, width: 300, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(filledTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'searchField' });
+      await expect(mwExpect(locator).toBeEmpty({ timeout: 200 })).rejects.toThrow(ExpectError);
+    });
+
+    test('not.toBeEmpty passes when value is not empty', async () => {
+      const filledTree: ViewNode[] = [
+        node({
+          type: 'Window',
+          children: [
+            node({
+              type: 'TextField',
+              label: 'Name',
+              identifier: 'nameField',
+              value: 'Alice',
+              bounds: { x: 0, y: 0, width: 300, height: 44 },
+            }),
+          ],
+        }),
+      ];
+      const driver = createMockDriver(filledTree);
+      const locator = new Locator(driver, { kind: 'testId', value: 'nameField' });
+      await mwExpect(locator).not.toBeEmpty();
+    });
+  });
+
   test.describe('toHaveValue', () => {
     test('passes with exact value match', async () => {
       const valueTree: ViewNode[] = [

--- a/packages/mobilewright-core/src/expect.ts
+++ b/packages/mobilewright-core/src/expect.ts
@@ -84,6 +84,39 @@ class LocatorAssertions {
     );
   }
 
+  async toHaveCount(expected: number, opts?: ExpectOptions): Promise<void> {
+    let lastCount = 0;
+    await this.retryAssertion(
+      async () => { lastCount = await this.locator.count(); return lastCount; },
+      (count) => {
+        const matches = count === expected;
+        return this.negated ? !matches : matches;
+      },
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      () => this.negated
+        ? `Expected element count NOT to be ${expected}, but got ${lastCount}`
+        : `Expected element count to be ${expected}, but got ${lastCount}`,
+    );
+  }
+
+  async toBeEmpty(opts?: ExpectOptions): Promise<void> {
+    let lastValue = '';
+    await this.retryAssertion(
+      async () => {
+        try { lastValue = await this.locator.getValue({ timeout: 0 }); } catch { lastValue = ''; }
+        return lastValue;
+      },
+      (value) => {
+        const isEmpty = value === '';
+        return this.negated ? !isEmpty : isEmpty;
+      },
+      opts?.timeout ?? DEFAULT_TIMEOUT,
+      () => this.negated
+        ? `Expected element NOT to be empty, but it was`
+        : `Expected element to be empty, but got "${lastValue}"`,
+    );
+  }
+
   async toHaveValue(expected: string | RegExp, opts?: ExpectOptions): Promise<void> {
     let lastValue = '';
     await this.retryAssertion(


### PR DESCRIPTION
## Summary

Adds two new locator assertions to `LocatorAssertions` in `expect.ts`, matching the Playwright API surface:

- **`toHaveCount(n)`** - polls until the number of elements matched by a locator equals `n`.
- **`toBeEmpty()`** - polls until a form element's `value` is an empty string.

Both assertions support `.not` negation and an optional `{ timeout }` override, consistent with all other assertions in the file.
Also added unit tests for these two assertions.
## Test plan

- [x] `expect(locator).toHaveCount(3)` passes when count matches
- [x] `expect(locator).toHaveCount(5)` throws `ExpectError` on mismatch (with short timeout)
- [x] `expect(locator).not.toHaveCount(5)` passes when count differs
- [x] `expect(locator).toHaveCount(0)` passes when nothing is found
- [x] `expect(locator).toBeEmpty()` passes when `value` is `""`
- [x] `expect(locator).toBeEmpty()` throws when value is non-empty
- [x] `expect(locator).not.toBeEmpty()` passes when value is non-empty
- [x] All unit tests pass