### PR TITLE
fix(locator): do not swallow driver errors in isVisible

### DIFF
--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -210,6 +210,17 @@ test.describe('Locator', () => {
 
       await expect(locator.tap()).rejects.toThrow(/not enabled/);
     });
+
+    test('isVisible rethrows non-locator errors', async () => {
+      const driver = createMockDriver([]);
+      driver.getViewHierarchy = async () => {
+        throw new Error('device disconnected');
+      };
+
+      const locator = new Locator(driver, { kind: 'testId', value: 'missing' });
+
+      await expect(locator.isVisible()).rejects.toThrow('device disconnected');
+    });
   });
 
   test.describe('waitFor', () => {

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -177,8 +177,10 @@ export class Locator {
     try {
       await this.waitFor({ state: 'visible', timeout: opts?.timeout ?? 0 });
       return true;
-    } catch(error) {
-      if(!(error instanceof LocatorError)) {throw error; }
+    } catch (error) {
+      if (!(error instanceof LocatorError)) {
+        throw error;
+      }
       return false;
     }
   }

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -172,12 +172,13 @@ export class Locator {
     const node = await this.resolve(0);
     return node !== null;
   }
-  
+
   async isVisible(opts?: { timeout?: number }): Promise<boolean> {
     try {
       await this.waitFor({ state: 'visible', timeout: opts?.timeout ?? 0 });
       return true;
-    } catch {
+    } catch(error) {
+      if(!(error instanceof LocatorError)) {throw error; }
       return false;
     }
   }


### PR DESCRIPTION
  Fixes `Locator.isVisible()` so it only returns `false` for expected locator lookup failures.

  Previously, `isVisible()` caught every thrown error and returned `false`. That could hide real driver/session/device failures, for example if the device disconnected while reading the view hierarchy.