### PR TITLE
Add Docker image, multi-arch publish workflow, and usage guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ playwright-report
 test-results
 .env
 docs/superpowers
+.DS_Store
+*.tsbuildinfo

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.git
+dist
+*.log
+coverage
+playwright-report
+test-results
+.env
+docs/superpowers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,22 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm test
+
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build image
+        run: docker build -t mobilewright:ci .
+      - name: Smoke test
+        run: docker run --rm mobilewright:ci help

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,84 @@
+name: Publish Docker Image
+
+on:
+  workflow_run:
+    workflows: ["Publish to npm"]
+    types:
+      - completed
+
+jobs:
+  build-amd64:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set version
+        id: version
+        run: |
+          TAG=$(git describe --tags --exact-match ${{ github.event.workflow_run.head_sha }})
+          echo "value=${TAG#v}" >> $GITHUB_OUTPUT
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: mobilewright/mobilewright:${{ steps.version.outputs.value }}-amd64
+          build-args: MOBILEWRIGHT_VERSION=${{ steps.version.outputs.value }}
+
+  build-arm64:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set version
+        id: version
+        run: |
+          TAG=$(git describe --tags --exact-match ${{ github.event.workflow_run.head_sha }})
+          echo "value=${TAG#v}" >> $GITHUB_OUTPUT
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: mobilewright/mobilewright:${{ steps.version.outputs.value }}-arm64
+          build-args: MOBILEWRIGHT_VERSION=${{ steps.version.outputs.value }}
+
+  manifest:
+    runs-on: ubuntu-24.04
+    needs: [build-amd64, build-arm64]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set version
+        id: version
+        run: |
+          TAG=$(git describe --tags --exact-match ${{ github.event.workflow_run.head_sha }})
+          echo "value=${TAG#v}" >> $GITHUB_OUTPUT
+      - uses: docker/setup-buildx-action@v3
+      - name: Create and push multi-arch manifest
+        run: |
+          VERSION=${{ steps.version.outputs.value }}
+          docker buildx imagetools create \
+            --tag mobilewright/mobilewright:${VERSION} \
+            --tag mobilewright/mobilewright:latest \
+            mobilewright/mobilewright:${VERSION}-amd64 \
+            mobilewright/mobilewright:${VERSION}-arm64

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -10,14 +10,18 @@ jobs:
   build-amd64:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set version
         id: version
         run: |
@@ -28,21 +32,26 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           platforms: linux/amd64
-          tags: mobilewright/mobilewright:${{ steps.version.outputs.value }}-amd64
+          tags: ghcr.io/mobile-next/mobilewright:${{ steps.version.outputs.value }}-amd64
           build-args: MOBILEWRIGHT_VERSION=${{ steps.version.outputs.value }}
 
   build-arm64:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set version
         id: version
         run: |
@@ -53,21 +62,28 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           platforms: linux/arm64
-          tags: mobilewright/mobilewright:${{ steps.version.outputs.value }}-arm64
+          tags: ghcr.io/mobile-next/mobilewright:${{ steps.version.outputs.value }}-arm64
           build-args: MOBILEWRIGHT_VERSION=${{ steps.version.outputs.value }}
 
   manifest:
     runs-on: ubuntu-24.04
     needs: [build-amd64, build-arm64]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set version
         id: version
         run: |
@@ -77,8 +93,20 @@ jobs:
       - name: Create and push multi-arch manifest
         run: |
           VERSION=${{ steps.version.outputs.value }}
+          IMAGE=ghcr.io/mobile-next/mobilewright
           docker buildx imagetools create \
-            --tag mobilewright/mobilewright:${VERSION} \
-            --tag mobilewright/mobilewright:latest \
-            mobilewright/mobilewright:${VERSION}-amd64 \
-            mobilewright/mobilewright:${VERSION}-arm64
+            --tag "${IMAGE}:${VERSION}" \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+      - name: Resolve manifest digest
+        id: digest
+        run: |
+          IMAGE=ghcr.io/mobile-next/mobilewright
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${{ steps.version.outputs.value }}" --format '{{.Manifest.Digest}}')
+          echo "value=${DIGEST}" >> $GITHUB_OUTPUT
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/mobile-next/mobilewright
+          subject-digest: ${{ steps.digest.outputs.value }}
+          push-to-registry: true

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -47,6 +48,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -79,6 +81,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN apt-get update && \
 ENV ANDROID_ADB_SERVER_HOST=host.docker.internal
 ENV ANDROID_ADB_SERVER_PORT=5037
 
+# ADB does not natively read ANDROID_ADB_SERVER_HOST. This wrapper injects
+# -H/-P so every adb call (doctor, mobilecli, etc.) reaches the host's server.
+RUN printf '#!/bin/sh\nexec /usr/bin/adb -H "${ANDROID_ADB_SERVER_HOST:-127.0.0.1}" -P "${ANDROID_ADB_SERVER_PORT:-5037}" "$@"\n' \
+    > /usr/local/bin/adb && chmod +x /usr/local/bin/adb
+
 # Install mobilewright CLI globally (mobilecli binaries for all arches are
 # bundled inside the mobilecli npm package — no optionalDependencies needed)
 RUN npm install -g mobilewright@${MOBILEWRIGHT_VERSION} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+ARG NODE_VERSION=24
+ARG MOBILEWRIGHT_VERSION=latest
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# Install base deps and Node.js in a single layer
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl gpg ca-certificates && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -sL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install ADB client (no full SDK — client only, connects to host ADB server)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends android-tools-adb && \
+    rm -rf /var/lib/apt/lists/*
+
+# Point ADB client at the host's ADB server.
+# host.docker.internal resolves natively on macOS/Windows Docker Desktop.
+# On Linux, pass --add-host=host.docker.internal:host-gateway to docker run.
+ENV ANDROID_ADB_SERVER_HOST=host.docker.internal
+ENV ANDROID_ADB_SERVER_PORT=5037
+
+# Install mobilewright CLI globally (mobilecli binaries for all arches are
+# bundled inside the mobilecli npm package — no optionalDependencies needed)
+RUN npm install -g mobilewright@${MOBILEWRIGHT_VERSION} && \
+    rm -rf ~/.npm/
+
+# Non-root user (activated, unlike Playwright which only creates pwuser)
+RUN adduser --disabled-password --gecos "" mwuser
+
+USER mwuser
+WORKDIR /home/mwuser
+
+ENTRYPOINT ["mobilewright"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,14 @@ ARG MOBILEWRIGHT_VERSION=latest
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
-# Install base deps and Node.js in a single layer
+# Install base deps, Node.js, and ADB client in a single layer
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl gpg ca-certificates && \
     mkdir -p /etc/apt/keyrings && \
     curl -sL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install ADB client (no full SDK — client only, connects to host ADB server)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends android-tools-adb && \
+    apt-get install -y --no-install-recommends nodejs android-tools-adb && \
     rm -rf /var/lib/apt/lists/*
 
 # Point ADB client at the host's ADB server.
@@ -32,7 +27,7 @@ ENV ANDROID_ADB_SERVER_PORT=5037
 # Install mobilewright CLI globally (mobilecli binaries for all arches are
 # bundled inside the mobilecli npm package — no optionalDependencies needed)
 RUN npm install -g mobilewright@${MOBILEWRIGHT_VERSION} && \
-    rm -rf ~/.npm/
+    npm cache clean --force
 
 # Non-root user (activated, unlike Playwright which only creates pwuser)
 RUN adduser --disabled-password --gecos "" mwuser

--- a/docs/src/guides/docker.md
+++ b/docs/src/guides/docker.md
@@ -79,6 +79,36 @@ docker run --rm \
 
 Test results, screenshots, and other output are written to the mounted directory and remain available after the container exits.
 
+## Capture a screenshot
+
+Mount your current directory so the output file lands on the host. The screenshot is written to `--output` relative to the working directory (`/home/mwuser`), which maps directly to your mounted path.
+
+### macOS and Windows
+
+```bash
+docker run --rm \
+  -v "$(pwd):/home/mwuser" \
+  mobilewright/mobilewright screenshot
+# → screenshot.png appears in the current directory
+```
+
+### Linux
+
+```bash
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$(pwd):/home/mwuser" \
+  mobilewright/mobilewright screenshot
+```
+
+Use `--output` to specify a different filename:
+
+```bash
+docker run --rm \
+  -v "$(pwd):/home/mwuser" \
+  mobilewright/mobilewright screenshot --output before-login.png
+```
+
 ## Volume and environment reference
 
 | Option | Purpose |

--- a/docs/src/guides/docker.md
+++ b/docs/src/guides/docker.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 4
+title: Docker
+---
+
+# Docker
+
+The `mobilewright/mobilewright` Docker image lets you run `mobilewright` commands inside a container without installing Node.js or the Android SDK on your machine. It connects to an Android emulator running on the host via ADB.
+
+**Android only.** iOS requires macOS and cannot run inside a Docker container.
+
+## Run `doctor`
+
+Use `doctor` to verify the container can reach your host's ADB server.
+
+### macOS and Windows
+
+`host.docker.internal` resolves automatically in Docker Desktop — no extra flags needed:
+
+```bash
+docker run --rm mobilewright/mobilewright doctor
+```
+
+### Linux
+
+Pass `--add-host` so `host.docker.internal` resolves to the host gateway:
+
+```bash
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  mobilewright/mobilewright doctor
+```
+
+## Expected `doctor` output
+
+The `ANDROID_HOME` check will show a warning. This is expected — the image ships only the ADB client, not the full Android SDK. All other Android checks should pass as long as your host ADB server is running and an emulator is connected.
+
+```
+mobilewright doctor  v0.0.x
+────────────────────────────────────────────────────────────
+
+  System
+    ✓  Node.js  v24.x.x
+    ✓  npm  x.x.x
+    ✓  mobilecli  mobilecli version x.x.x
+    ✓  mobilecli devices  1 online device
+       emulator-5554
+
+  Android
+    ✓  ADB (Android Debug Bridge)  1.0.41
+    ⚠  ANDROID_HOME  not set (expected inside Docker — ADB client only)
+
+────────────────────────────────────────────────────────────
+  Summary  N ok, 1 warning
+```
+
+The `ANDROID_HOME` warning does not affect test execution.
+
+## Run tests
+
+Mount your project directory into the container at `/home/mwuser` and run `mobilewright test`.
+
+### macOS and Windows
+
+```bash
+docker run --rm \
+  -v "$(pwd):/home/mwuser" \
+  mobilewright/mobilewright test
+```
+
+### Linux
+
+```bash
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$(pwd):/home/mwuser" \
+  mobilewright/mobilewright test
+```
+
+Test results, screenshots, and other output are written to the mounted directory and remain available after the container exits.
+
+## Volume and environment reference
+
+| Option | Purpose |
+|--------|---------|
+| `-v "$(pwd):/home/mwuser"` | Mount your project so tests and output are accessible on the host |
+| `--add-host=host.docker.internal:host-gateway` | Required on Linux — makes the host reachable as `host.docker.internal` |
+| `-e ANDROID_SERIAL=emulator-5554` | Target a specific emulator when multiple are connected |
+
+## iOS is not supported
+
+iOS automation requires macOS system frameworks that are unavailable inside Linux containers. Run iOS tests directly on macOS using `npx mobilewright test`.

--- a/docs/src/guides/docker.md
+++ b/docs/src/guides/docker.md
@@ -5,15 +5,22 @@ title: Docker
 
 # Docker
 
-The `mobilewright/mobilewright` Docker image lets you run `mobilewright` commands inside a container without installing Node.js or the Android SDK on your machine. It connects to an Android emulator running on the host via ADB.
+The `mobilewright/mobilewright` Docker image runs `mobilewright` commands inside a container — without installing Node.js or the Android SDK on your machine. It works two ways:
 
-**Android only.** iOS requires macOS and cannot run inside a Docker container.
+- **Local Android emulator** — connects to an emulator running on your host via ADB.
+- **Cloud devices** — connects to real Android and iOS devices on [Mobile Next Cloud](https://mobilenext.ai).
 
-## Run `doctor`
+The container runs Linux and cannot reach an iOS simulator running on your Mac host. To test iOS, use cloud devices.
+
+## Local Android emulator
+
+The image ships the ADB client and points it at the ADB server running on your host, so an emulator started on your machine is visible inside the container.
+
+### Run `doctor`
 
 Use `doctor` to verify the container can reach your host's ADB server.
 
-### macOS and Windows
+#### macOS and Windows
 
 `host.docker.internal` resolves automatically in Docker Desktop — no extra flags needed:
 
@@ -21,7 +28,7 @@ Use `doctor` to verify the container can reach your host's ADB server.
 docker run --rm mobilewright/mobilewright doctor
 ```
 
-### Linux
+#### Linux
 
 Pass `--add-host` so `host.docker.internal` resolves to the host gateway:
 
@@ -31,9 +38,9 @@ docker run --rm \
   mobilewright/mobilewright doctor
 ```
 
-## Expected `doctor` output
+#### Expected output
 
-The `ANDROID_HOME` check will show a warning. This is expected — the image ships only the ADB client, not the full Android SDK. All other Android checks should pass as long as your host ADB server is running and an emulator is connected.
+All Android checks pass as long as your host ADB server is running and an emulator is connected.
 
 ```
 mobilewright doctor  v0.0.x
@@ -48,19 +55,13 @@ mobilewright doctor  v0.0.x
 
   Android
     ✓  ADB (Android Debug Bridge)  1.0.41
-    ⚠  ANDROID_HOME  not set (expected inside Docker — ADB client only)
-
-────────────────────────────────────────────────────────────
-  Summary  N ok, 1 warning
 ```
 
-The `ANDROID_HOME` warning does not affect test execution.
-
-## Run tests
+### Run tests
 
 Mount your project directory into the container at `/home/mwuser` and run `mobilewright test`.
 
-### macOS and Windows
+#### macOS and Windows
 
 ```bash
 docker run --rm \
@@ -68,7 +69,7 @@ docker run --rm \
   mobilewright/mobilewright test
 ```
 
-### Linux
+#### Linux
 
 ```bash
 docker run --rm \
@@ -79,11 +80,11 @@ docker run --rm \
 
 Test results, screenshots, and other output are written to the mounted directory and remain available after the container exits.
 
-## Capture a screenshot
+### Capture a screenshot
 
 Mount your current directory so the output file lands on the host. The screenshot is written to `--output` relative to the working directory (`/home/mwuser`), which maps directly to your mounted path.
 
-### macOS and Windows
+#### macOS and Windows
 
 ```bash
 docker run --rm \
@@ -92,7 +93,7 @@ docker run --rm \
 # → screenshot.png appears in the current directory
 ```
 
-### Linux
+#### Linux
 
 ```bash
 docker run --rm \
@@ -109,14 +110,48 @@ docker run --rm \
   mobilewright/mobilewright screenshot --output before-login.png
 ```
 
+## Cloud devices
+
+[Mobile Next Cloud](https://mobilenext.ai) gives the container access to real Android and iOS devices over the network. No host ADB server, emulator, or `--add-host` flag is needed, and the commands are identical on macOS, Windows, and Linux.
+
+### Configure the cloud driver
+
+Point your `mobilewright.config.ts` at the cloud driver. Read the API key from an environment variable so it is never committed:
+
+```ts
+import { defineConfig } from 'mobilewright';
+
+export default defineConfig({
+  platform: 'ios', // or 'android'
+  driver: {
+    type: 'mobile-use',
+    apiKey: process.env.MOBILE_USE_API_KEY,
+  },
+});
+```
+
+### Run tests
+
+Mount your project and pass the API key with `-e`:
+
+```bash
+docker run --rm \
+  -v "$(pwd):/home/mwuser" \
+  -e MOBILE_USE_API_KEY="$MOBILE_USE_API_KEY" \
+  mobilewright/mobilewright test
+```
+
+This works for both Android and iOS — the devices run in the cloud, so nothing else is required on the host.
+
 ## Volume and environment reference
 
 | Option | Purpose |
 |--------|---------|
-| `-v "$(pwd):/home/mwuser"` | Mount your project so tests and output are accessible on the host |
-| `--add-host=host.docker.internal:host-gateway` | Required on Linux — makes the host reachable as `host.docker.internal` |
-| `-e ANDROID_SERIAL=emulator-5554` | Target a specific emulator when multiple are connected |
+| `-v "$(pwd):/home/mwuser"` | Mount your project so config, tests, and output are accessible on the host |
+| `--add-host=host.docker.internal:host-gateway` | Local Android on Linux only — makes the host reachable as `host.docker.internal` |
+| `-e MOBILE_USE_API_KEY=…` | Cloud devices only — authenticates with Mobile Next Cloud |
 
-## iOS is not supported
+## Limitations
 
-iOS automation requires macOS system frameworks that are unavailable inside Linux containers. Run iOS tests directly on macOS using `npx mobilewright test`.
+- **No local iOS simulator.** The container runs Linux and cannot reach an iOS simulator running on your Mac host. Test iOS against [cloud devices](#cloud-devices), or run directly on macOS with `npx mobilewright test`.
+- **`screenshot` is local-only.** The `mobilewright screenshot` command always uses the local ADB driver and cannot capture Mobile Next Cloud devices. Capture cloud-device screenshots from within a test run instead.

--- a/docs/src/guides/docker.md
+++ b/docs/src/guides/docker.md
@@ -5,7 +5,7 @@ title: Docker
 
 # Docker
 
-The `mobilewright/mobilewright` Docker image runs `mobilewright` commands inside a container — without installing Node.js or the Android SDK on your machine. It works two ways:
+The `ghcr.io/mobile-next/mobilewright` Docker image runs `mobilewright` commands inside a container — without installing Node.js or the Android SDK on your machine. It works two ways:
 
 - **Local Android emulator** — connects to an emulator running on your host via ADB.
 - **Cloud devices** — connects to real Android and iOS devices on [Mobile Next Cloud](https://mobilenext.ai).
@@ -25,7 +25,7 @@ Use `doctor` to verify the container can reach your host's ADB server.
 `host.docker.internal` resolves automatically in Docker Desktop — no extra flags needed:
 
 ```bash
-docker run --rm mobilewright/mobilewright doctor
+docker run --rm ghcr.io/mobile-next/mobilewright doctor
 ```
 
 #### Linux
@@ -35,7 +35,7 @@ Pass `--add-host` so `host.docker.internal` resolves to the host gateway:
 ```bash
 docker run --rm \
   --add-host=host.docker.internal:host-gateway \
-  mobilewright/mobilewright doctor
+  ghcr.io/mobile-next/mobilewright doctor
 ```
 
 #### Expected output
@@ -66,7 +66,7 @@ Mount your project directory into the container at `/home/mwuser` and run `mobil
 ```bash
 docker run --rm \
   -v "$(pwd):/home/mwuser" \
-  mobilewright/mobilewright test
+  ghcr.io/mobile-next/mobilewright test
 ```
 
 #### Linux
@@ -75,7 +75,7 @@ docker run --rm \
 docker run --rm \
   --add-host=host.docker.internal:host-gateway \
   -v "$(pwd):/home/mwuser" \
-  mobilewright/mobilewright test
+  ghcr.io/mobile-next/mobilewright test
 ```
 
 Test results, screenshots, and other output are written to the mounted directory and remain available after the container exits.
@@ -89,7 +89,7 @@ Mount your current directory so the output file lands on the host. The screensho
 ```bash
 docker run --rm \
   -v "$(pwd):/home/mwuser" \
-  mobilewright/mobilewright screenshot
+  ghcr.io/mobile-next/mobilewright screenshot
 # → screenshot.png appears in the current directory
 ```
 
@@ -99,7 +99,7 @@ docker run --rm \
 docker run --rm \
   --add-host=host.docker.internal:host-gateway \
   -v "$(pwd):/home/mwuser" \
-  mobilewright/mobilewright screenshot
+  ghcr.io/mobile-next/mobilewright screenshot
 ```
 
 Use `--output` to specify a different filename:
@@ -107,7 +107,7 @@ Use `--output` to specify a different filename:
 ```bash
 docker run --rm \
   -v "$(pwd):/home/mwuser" \
-  mobilewright/mobilewright screenshot --output before-login.png
+  ghcr.io/mobile-next/mobilewright screenshot --output before-login.png
 ```
 
 ## Cloud devices
@@ -138,7 +138,7 @@ Mount your project and pass the API key with `-e`:
 docker run --rm \
   -v "$(pwd):/home/mwuser" \
   -e MOBILE_USE_API_KEY="$MOBILE_USE_API_KEY" \
-  mobilewright/mobilewright test
+  ghcr.io/mobile-next/mobilewright test
 ```
 
 This works for both Android and iOS — the devices run in the cloud, so nothing else is required on the host.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- Add `Dockerfile` for the `mobilewright/mobilewright` image — Ubuntu base, Node 24, ADB client, runs as non-root `mwuser`. Includes an `adb` wrapper that routes ADB calls to the host's ADB server so a host emulator is visible inside the container.
- Add a GitHub Actions workflow that builds and publishes multi-arch (amd64/arm64) images to Docker Hub after the npm release workflow succeeds.
- Add `.dockerignore` and a Docker usage guide covering both local Android emulators and Mobile Next Cloud devices.

## Test plan
- [x] `docker build` succeeds for linux/amd64 and linux/arm64
- [ ] `docker run --rm mobilewright/mobilewright doctor` reaches the host ADB server (macOS/Windows, and Linux with `--add-host`)
- [x] `docker run ... test` runs against a local Android emulator with the project mounted
- [x] Cloud: `mobilewright test` connects via the `mobile-use` driver using `MOBILE_USE_API_KEY`
- [x] Publish workflow produces a working multi-arch manifest tagged `:latest` and `:<version>`