### PR TITLE
test: improve unit test coverage for locator, stackTrace, and resolve-binary

### DIFF
--- a/packages/driver-mobilecli/src/resolve-binary.test.ts
+++ b/packages/driver-mobilecli/src/resolve-binary.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { resolveMobilecliBinary } from './resolve-binary.js';
+
+function simulatePlatform(platform: string, arch: string, fn: () => void): void {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  const archDescriptor = Object.getOwnPropertyDescriptor(process, 'arch')!;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', platformDescriptor);
+    Object.defineProperty(process, 'arch', archDescriptor);
+  }
+}
+
+test('resolveMobilecliBinary returns a path to the darwin-arm64 binary', () => {
+  simulatePlatform('darwin', 'arm64', () => {
+    expect(resolveMobilecliBinary()).toContain('mobilecli-darwin-arm64');
+  });
+});
+
+test('resolveMobilecliBinary returns a path to the darwin-amd64 binary for x64', () => {
+  simulatePlatform('darwin', 'x64', () => {
+    expect(resolveMobilecliBinary()).toContain('mobilecli-darwin-amd64');
+  });
+});
+
+test('resolveMobilecliBinary returns a path to the linux-arm64 binary', () => {
+  simulatePlatform('linux', 'arm64', () => {
+    expect(resolveMobilecliBinary()).toContain('mobilecli-linux-arm64');
+  });
+});
+
+test('resolveMobilecliBinary returns a path to the linux-amd64 binary for x64', () => {
+  simulatePlatform('linux', 'x64', () => {
+    expect(resolveMobilecliBinary()).toContain('mobilecli-linux-amd64');
+  });
+});
+
+test('resolveMobilecliBinary returns a path to the windows-amd64 binary for win32-x64', () => {
+  simulatePlatform('win32', 'x64', () => {
+    expect(resolveMobilecliBinary()).toContain('mobilecli-windows-amd64.exe');
+  });
+});
+
+test('resolveMobilecliBinary throws an error for an unsupported platform', () => {
+  simulatePlatform('freebsd', 'x64', () => {
+    expect(() => resolveMobilecliBinary()).toThrow('Unsupported platform: freebsd-x64');
+  });
+});

--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import sharp from 'sharp';
 import type {
   MobilewrightDriver,
   ViewNode,
@@ -397,6 +398,241 @@ test.describe('Locator', () => {
 
       await locator.tap();
       expect(driver._tracker.tapCalls).toEqual([[195, 66]]);
+    });
+  });
+
+  test.describe('doubleTap', () => {
+    test('double-taps at the center of the matched element', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      await locator.doubleTap();
+
+      expect(driver._tracker.doubleTapCalls).toEqual([[120, 125]]);
+    });
+
+    test('throws LocatorError when element not found', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Nonexistent' }, { timeout: 100 });
+
+      await expect(locator.doubleTap()).rejects.toThrow(LocatorError);
+    });
+  });
+
+  test.describe('longPress', () => {
+    test('long-presses at the center of the matched element', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      await locator.longPress();
+
+      expect(driver._tracker.longPressCalls).toEqual([[120, 125, undefined]]);
+    });
+
+    test('passes duration through to the driver', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      await locator.longPress({ duration: 1500 });
+
+      expect(driver._tracker.longPressCalls).toEqual([[120, 125, 1500]]);
+    });
+  });
+
+  test.describe('exists', () => {
+    test('returns true when the element is present', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      expect(await locator.exists()).toBe(true);
+    });
+
+    test('returns false when the element is absent', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Nonexistent' });
+
+      expect(await locator.exists()).toBe(false);
+    });
+  });
+
+  test.describe('boolean state queries', () => {
+    test('isEnabled returns true for an enabled element', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      expect(await locator.isEnabled()).toBe(true);
+    });
+
+    test('isEnabled returns false for a disabled element', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Cancel' });
+
+      expect(await locator.isEnabled()).toBe(false);
+    });
+
+    test('isSelected returns true when the node has isSelected set', async () => {
+      const tree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Tab', label: 'Home', isSelected: true })] })];
+      const driver = createMockDriver(tree);
+      const locator = new Locator(driver, { kind: 'label', value: 'Home' });
+
+      expect(await locator.isSelected()).toBe(true);
+    });
+
+    test('isSelected returns false when isSelected is not set', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      expect(await locator.isSelected()).toBe(false);
+    });
+
+    test('isFocused returns true when the node has isFocused set', async () => {
+      const tree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'TextField', label: 'Search', isFocused: true })] })];
+      const driver = createMockDriver(tree);
+      const locator = new Locator(driver, { kind: 'label', value: 'Search' });
+
+      expect(await locator.isFocused()).toBe(true);
+    });
+
+    test('isChecked returns true when the node has isChecked set', async () => {
+      const tree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Checkbox', label: 'Agree', isChecked: true })] })];
+      const driver = createMockDriver(tree);
+      const locator = new Locator(driver, { kind: 'label', value: 'Agree' });
+
+      expect(await locator.isChecked()).toBe(true);
+    });
+
+    test('isChecked returns false when isChecked is not set', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      expect(await locator.isChecked()).toBe(false);
+    });
+  });
+
+  test.describe('boundingBox', () => {
+    test('returns the x, y, width, height of the visible element', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      const box = await locator.boundingBox();
+
+      expect(box).toEqual({ x: 20, y: 100, width: 200, height: 50 });
+    });
+  });
+
+  test.describe('getValue', () => {
+    test('returns the value property of the element when present', async () => {
+      const tree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Slider', label: 'Volume', value: '75%' })] })];
+      const driver = createMockDriver(tree);
+      const locator = new Locator(driver, { kind: 'label', value: 'Volume' });
+
+      expect(await locator.getValue()).toBe('75%');
+    });
+
+    test('returns an empty string when value is not set', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      expect(await locator.getValue()).toBe('');
+    });
+  });
+
+  test.describe('waitFor enabled and disabled states', () => {
+    test('resolves immediately when element is already enabled', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      await locator.waitFor({ state: 'enabled' });
+    });
+
+    test('resolves immediately when element is already disabled', async () => {
+      const driver = createMockDriver(hierarchy);
+      const locator = new Locator(driver, { kind: 'label', value: 'Cancel' });
+
+      await locator.waitFor({ state: 'disabled' });
+    });
+  });
+
+  test.describe('scrollIntoViewIfNeeded', () => {
+    test('returns immediately without swiping when element is already in the viewport', async () => {
+      const driver = createMockDriver(hierarchy);
+      // Submit button at x:20 y:100 w:200 h:50 — fully inside the 390×844 screen
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+
+      await locator.scrollIntoViewIfNeeded();
+
+      expect(driver._tracker.swipeCalls).toHaveLength(0);
+    });
+
+    test('swipes up when the element is below the visible viewport', async () => {
+      const belowBounds = { x: 0, y: 900, width: 390, height: 44 };
+      const inViewBounds = { x: 0, y: 400, width: 390, height: 44 };
+      const belowTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: belowBounds })] })];
+      const inViewTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: inViewBounds })] })];
+
+      const driver = createMockDriver(belowTree);
+      let callCount = 0;
+      driver.getViewHierarchy = async () => {
+        callCount++;
+        return callCount >= 2 ? inViewTree : belowTree;
+      };
+
+      const locator = new Locator(driver, { kind: 'label', value: 'Far' });
+      await locator.scrollIntoViewIfNeeded({ maxSwipes: 5 });
+
+      // centerY of belowBounds = 900 + 22 = 922 > 844, so swipeDirectionToReveal returns 'up'
+      expect(driver._tracker.swipeCalls[0]).toEqual(['up']);
+    });
+
+    test('swipes down when the element is above the visible viewport', async () => {
+      const aboveBounds = { x: 0, y: -200, width: 390, height: 44 };
+      const inViewBounds = { x: 0, y: 400, width: 390, height: 44 };
+      const aboveTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: aboveBounds })] })];
+      const inViewTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: inViewBounds })] })];
+
+      const driver = createMockDriver(aboveTree);
+      let callCount = 0;
+      driver.getViewHierarchy = async () => {
+        callCount++;
+        return callCount >= 2 ? inViewTree : aboveTree;
+      };
+
+      const locator = new Locator(driver, { kind: 'label', value: 'Far' });
+      await locator.scrollIntoViewIfNeeded({ maxSwipes: 5 });
+
+      // centerY of aboveBounds = -200 + 22 = -178, not > 844, so swipeDirectionToReveal returns 'down'
+      expect(driver._tracker.swipeCalls[0]).toEqual(['down']);
+    });
+
+    test('throws LocatorError when element never enters the viewport within maxSwipes', async () => {
+      const outOfViewBounds = { x: 0, y: 900, width: 390, height: 44 };
+      const outOfViewTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: outOfViewBounds })] })];
+
+      const driver = createMockDriver(outOfViewTree);
+      const locator = new Locator(driver, { kind: 'label', value: 'Far' });
+
+      await expect(locator.scrollIntoViewIfNeeded({ maxSwipes: 1 })).rejects.toThrow(LocatorError);
+    });
+  });
+
+  test.describe('screenshot', () => {
+    test('returns a buffer cropped to the element bounds', async () => {
+      const screenWidth = 390;
+      const screenHeight = 844;
+      const fullImage = await sharp({
+        create: { width: screenWidth, height: screenHeight, channels: 3, background: { r: 100, g: 150, b: 200 } },
+      }).png().toBuffer();
+
+      const driver = createMockDriver(hierarchy);
+      driver.screenshot = async () => fullImage;
+
+      // Submit button: x:20, y:100, width:200, height:50
+      const locator = new Locator(driver, { kind: 'label', value: 'Submit' });
+      const cropped = await locator.screenshot();
+
+      const meta = await sharp(cropped).metadata();
+      expect(meta.width).toBe(200);
+      expect(meta.height).toBe(50);
     });
   });
 });

--- a/packages/mobilewright-core/src/stackTrace.test.ts
+++ b/packages/mobilewright-core/src/stackTrace.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { filterStack, captureLocation } from './stackTrace.js';
+
+const FRAMEWORK_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const aFrameworkFilePath = path.join(FRAMEWORK_ROOT, 'mobilewright-core', 'src', 'locator.ts');
+const aUserFilePath = '/home/user/my-test.ts';
+
+test('filterStack returns undefined when given no stack', () => {
+  expect(filterStack(undefined)).toBeUndefined();
+});
+
+test('filterStack returns the original stack unchanged when MWDEBUGIMPL is set', () => {
+  const stack = `Error\n    at fn (${aUserFilePath}:1:1)\n    at framework (${aFrameworkFilePath}:5:3)`;
+  process.env.MWDEBUGIMPL = '1';
+  try {
+    expect(filterStack(stack)).toBe(stack);
+  } finally {
+    delete process.env.MWDEBUGIMPL;
+  }
+});
+
+test('filterStack removes framework frames and keeps user frames', () => {
+  const userFrame = `    at myTest (${aUserFilePath}:10:5)`;
+  const frameworkFrame = `    at Locator.find (${aFrameworkFilePath}:50:3)`;
+  const stack = `Error: something\n${userFrame}\n${frameworkFrame}`;
+
+  const result = filterStack(stack);
+
+  expect(result).toContain(userFrame);
+  expect(result).not.toContain(frameworkFrame);
+});
+
+test('filterStack keeps the error message line even when all frames are framework frames', () => {
+  const frameworkFrame = `    at fn (${aFrameworkFilePath}:1:1)`;
+  const stack = `Error: the message\n${frameworkFrame}`;
+
+  const result = filterStack(stack);
+
+  expect(result).toContain('Error: the message');
+  expect(result).not.toContain(frameworkFrame);
+});
+
+test('captureLocation returns a location with a file path, line number, and column number', () => {
+  const location = captureLocation();
+
+  expect(location).toBeDefined();
+  expect(location!.file).toBeTruthy();
+  expect(location!.line).toBeGreaterThan(0);
+  expect(location!.column).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- Add tests for `stackTrace.ts`: `filterStack` (undefined input, MWDEBUGIMPL env var, framework frame filtering) and `captureLocation` — statement coverage 46% → 74%, function coverage 50% → 100%
- Add tests for `resolve-binary.ts`: all five platform/arch mappings and unsupported-platform error — coverage 24% → 100%
- Expand `locator.test.ts` with 23 new tests covering `doubleTap`, `longPress`, `exists`, `isEnabled/isSelected/isFocused/isChecked`, `boundingBox`, `getValue`, `waitFor` enabled/disabled states, `scrollIntoViewIfNeeded`, and `screenshot` — statement coverage 76% → 95%

## Test Plan
- [x] `npm run lint` passes
- [x] Full test suite passes (263 passed, 1 skipped)
- [x] Coverage verified via `npm run test:coverage`