### PR TITLE
feat: add filter(), and(), or() to Locator

### DIFF
--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -364,6 +364,48 @@ test.describe('Locator', () => {
     });
   });
 
+  test.describe('filter / and / or', () => {
+    const tree: ViewNode[] = [
+      node({
+        type: 'Window',
+        children: [
+          node({ type: 'Cell', label: 'Apple', text: 'Apple', bounds: { x: 0, y: 0, width: 390, height: 44 } }),
+          node({ type: 'Cell', label: 'Banana', text: 'Banana', bounds: { x: 0, y: 44, width: 390, height: 44 } }),
+          node({ type: 'Button', label: 'Apple', identifier: 'appleBtn', bounds: { x: 0, y: 88, width: 390, height: 44 } }),
+        ],
+      }),
+    ];
+
+    test('filter narrows by hasText', async () => {
+      const driver = createMockDriver(tree);
+      const cells = new Locator(driver, { kind: 'type', value: 'Cell' });
+
+      const text = await cells.filter({ hasText: 'Banana' }).getText();
+      expect(text).toBe('Banana');
+    });
+
+    test('and matches elements satisfying both locators', async () => {
+      const driver = createMockDriver(tree);
+      const byRole = new Locator(driver, { kind: 'role', value: 'button' });
+      const byLabel = new Locator(driver, { kind: 'label', value: 'Apple' });
+
+      const matched = byRole.and(byLabel);
+      const count = await matched.count();
+      const id = (await matched.all())[0];
+      expect(count).toBe(1);
+      expect(await id.getText()).toBe('Apple');
+    });
+
+    test('or matches elements satisfying either locator', async () => {
+      const driver = createMockDriver(tree);
+      const cells = new Locator(driver, { kind: 'type', value: 'Cell' });
+      const buttons = new Locator(driver, { kind: 'role', value: 'button' });
+
+      const count = await cells.or(buttons).count();
+      expect(count).toBe(3);
+    });
+  });
+
   test.describe('chaining', () => {
     test('supports chained locators', async () => {
       const treeWithList: ViewNode[] = [

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -14,6 +14,17 @@ export interface LocatorOptions {
   expectTimeout?: number;
 }
 
+export interface FilterOptions {
+  /** Keep only elements whose subtree contains this text. */
+  hasText?: string | RegExp;
+  /** Keep only elements whose subtree does NOT contain this text. */
+  hasNotText?: string | RegExp;
+  /** Keep only elements that contain an element matching this locator. */
+  has?: Locator;
+  /** Keep only elements that do NOT contain an element matching this locator. */
+  hasNot?: Locator;
+}
+
 export interface ScrollIntoViewOptions {
   /** Maximum number of swipe attempts before giving up (default: 10) */
   maxSwipes?: number;
@@ -74,13 +85,38 @@ export class Locator {
   }
 
   protected child(childStrategy: LocatorStrategy): Locator {
-    const loc = new Locator(
-      this.driver,
-      { kind: 'chain', parent: this.strategy, child: childStrategy },
-      this.options,
-    );
+    return this.withStrategy({ kind: 'chain', parent: this.strategy, child: childStrategy });
+  }
+
+  /** Build a sibling locator that shares this one's driver, options, and step fn. */
+  protected withStrategy(strategy: LocatorStrategy): Locator {
+    const loc = new Locator(this.driver, strategy, this.options);
     loc._stepFn = this._stepFn;
     return loc;
+  }
+
+  // ─── Narrowing & combining ───────────────────────────────────
+
+  /** Narrow this locator to elements matching the given conditions. */
+  filter(opts?: FilterOptions): Locator {
+    return this.withStrategy({
+      kind: 'filter',
+      parent: this.strategy,
+      hasText: opts?.hasText,
+      hasNotText: opts?.hasNotText,
+      has: opts?.has?.strategy,
+      hasNot: opts?.hasNot?.strategy,
+    });
+  }
+
+  /** Match elements that satisfy both this locator and the given locator. */
+  and(locator: Locator): Locator {
+    return this.withStrategy({ kind: 'and', left: this.strategy, right: locator.strategy });
+  }
+
+  /** Match elements that satisfy either this locator or the given locator. */
+  or(locator: Locator): Locator {
+    return this.withStrategy({ kind: 'or', left: this.strategy, right: locator.strategy });
   }
 
   // ─── Collection ──────────────────────────────────────────────
@@ -94,13 +130,7 @@ export class Locator {
   }
 
   nth(index: number): Locator {
-    const loc = new Locator(
-      this.driver,
-      { kind: 'nth', parent: this.strategy, index },
-      this.options,
-    );
-    loc._stepFn = this._stepFn;
-    return loc;
+    return this.withStrategy({ kind: 'nth', parent: this.strategy, index });
   }
 
   async count(): Promise<number> {

--- a/packages/mobilewright-core/src/query-engine.test.ts
+++ b/packages/mobilewright-core/src/query-engine.test.ts
@@ -448,3 +448,135 @@ test.describe('testId with resourceId', () => {
     expect(results).toHaveLength(0);
   });
 });
+
+test.describe('and strategy', () => {
+  test('matches only elements satisfying both locators', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'and',
+      left: { kind: 'role', value: 'button' },
+      right: { kind: 'label', value: 'Sign In' },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].identifier).toBe('loginButton');
+  });
+
+  test('returns empty when the two locators never overlap', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'and',
+      left: { kind: 'role', value: 'button' },
+      right: { kind: 'type', value: 'TextField' },
+    });
+    expect(results).toHaveLength(0);
+  });
+
+  test('preserves document order of the left locator', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'and',
+      left: { kind: 'role', value: 'button' },
+      right: { kind: 'role', value: 'button' },
+    });
+    expect(results.map((n) => n.identifier)).toEqual(['loginButton', 'forgotPassword']);
+  });
+});
+
+test.describe('or strategy', () => {
+  test('matches elements satisfying either locator', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'or',
+      left: { kind: 'type', value: 'TextField' },
+      right: { kind: 'type', value: 'SecureTextField' },
+    });
+    expect(results.map((n) => n.identifier)).toEqual(['emailField', 'passwordField']);
+  });
+
+  test('deduplicates elements matched by both locators', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'or',
+      left: { kind: 'role', value: 'button' },
+      right: { kind: 'label', value: 'Sign In' },
+    });
+    // loginButton matches both sides but appears once, in document order
+    expect(results.map((n) => n.identifier)).toEqual(['loginButton', 'forgotPassword']);
+  });
+});
+
+test.describe('filter strategy', () => {
+  test('hasText keeps elements whose own text matches', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'filter',
+      parent: { kind: 'type', value: 'Button' },
+      hasText: 'Forgot',
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].identifier).toBe('forgotPassword');
+  });
+
+  test('hasText keeps elements whose descendant text matches', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'filter',
+      parent: { kind: 'type', value: 'NavigationBar' },
+      hasText: 'Login',
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe('NavigationBar');
+  });
+
+  test('hasNotText drops elements containing the text', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'filter',
+      parent: { kind: 'role', value: 'button' },
+      hasNotText: 'Forgot',
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].identifier).toBe('loginButton');
+  });
+
+  test('has keeps elements with a matching descendant', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'filter',
+      parent: { kind: 'type', value: 'NavigationBar' },
+      has: { kind: 'type', value: 'StaticText' },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe('NavigationBar');
+  });
+
+  test('hasNot drops elements with a matching descendant', () => {
+    const results = queryAll(sampleTree, {
+      kind: 'filter',
+      parent: { kind: 'type', value: 'NavigationBar' },
+      hasNot: { kind: 'type', value: 'StaticText' },
+    });
+    expect(results).toHaveLength(0);
+  });
+});
+
+test.describe('filter strategy on flat hierarchy (bounds-based)', () => {
+  const flatList: ViewNode[] = [
+    node({ type: 'Cell', label: 'Row 1', bounds: { x: 0, y: 0, width: 400, height: 100 } }),
+    node({ type: 'StaticText', label: 'Title 1', text: 'Title 1', bounds: { x: 10, y: 10, width: 200, height: 30 } }),
+    node({ type: 'Button', label: 'Delete', identifier: 'delete1', bounds: { x: 300, y: 10, width: 80, height: 30 } }),
+    node({ type: 'Cell', label: 'Row 2', bounds: { x: 0, y: 100, width: 400, height: 100 } }),
+    node({ type: 'StaticText', label: 'Title 2', text: 'Title 2', bounds: { x: 10, y: 110, width: 200, height: 30 } }),
+  ];
+
+  test('has uses bounds containment when there are no tree children', () => {
+    const results = queryAll(flatList, {
+      kind: 'filter',
+      parent: { kind: 'type', value: 'Cell' },
+      has: { kind: 'role', value: 'button' },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].label).toBe('Row 1');
+  });
+
+  test('hasText uses bounds containment when there are no tree children', () => {
+    const results = queryAll(flatList, {
+      kind: 'filter',
+      parent: { kind: 'type', value: 'Cell' },
+      hasText: 'Title 2',
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].label).toBe('Row 2');
+  });
+});

--- a/packages/mobilewright-core/src/query-engine.ts
+++ b/packages/mobilewright-core/src/query-engine.ts
@@ -10,7 +10,17 @@ export type LocatorStrategy =
   | { kind: 'placeholder'; value: string; exact?: boolean }
   | { kind: 'webview'; testId?: string }
   | { kind: 'chain'; parent: LocatorStrategy; child: LocatorStrategy }
-  | { kind: 'nth'; parent: LocatorStrategy; index: number };
+  | { kind: 'nth'; parent: LocatorStrategy; index: number }
+  | {
+    kind: 'filter';
+    parent: LocatorStrategy;
+    hasText?: string | RegExp;
+    hasNotText?: string | RegExp;
+    has?: LocatorStrategy;
+    hasNot?: LocatorStrategy;
+  }
+  | { kind: 'and'; left: LocatorStrategy; right: LocatorStrategy }
+  | { kind: 'or'; left: LocatorStrategy; right: LocatorStrategy };
 
 /**
  * Query all ViewNodes in a tree that match a locator strategy.
@@ -25,6 +35,25 @@ export function queryAll(
     const index = strategy.index < 0 ? all.length + strategy.index : strategy.index;
     const node = all[index];
     return node ? [node] : [];
+  }
+
+  if (strategy.kind === 'and') {
+    const right = new Set(queryAll(roots, strategy.right));
+    return queryAll(roots, strategy.left).filter((node) => right.has(node));
+  }
+
+  if (strategy.kind === 'or') {
+    const matched = new Set([
+      ...queryAll(roots, strategy.left),
+      ...queryAll(roots, strategy.right),
+    ]);
+    // Return in document order, with duplicates removed
+    return flattenNodes(roots).filter((node) => matched.has(node));
+  }
+
+  if (strategy.kind === 'filter') {
+    const candidates = queryAll(roots, strategy.parent);
+    return candidates.filter((node) => matchesFilter(node, roots, strategy));
   }
 
   if (strategy.kind === 'chain') {
@@ -138,6 +167,9 @@ function matchesStrategy(
       return true;
 
     case 'chain':
+    case 'filter':
+    case 'and':
+    case 'or':
       // Handled above in queryAll
       return false;
 
@@ -179,6 +211,73 @@ function matchesRole(node: ViewNode, role: string): boolean {
   }
   // Fallback: direct type match
   return normalizedType === role.toLowerCase();
+}
+
+type FilterStrategy = Extract<LocatorStrategy, { kind: 'filter' }>;
+
+/** Decide whether a candidate node passes a filter strategy's conditions. */
+function matchesFilter(
+  node: ViewNode,
+  roots: ViewNode[],
+  strategy: FilterStrategy,
+): boolean {
+  if (strategy.hasText !== undefined && !subtreeContainsText(node, roots, strategy.hasText)) {
+    return false;
+  }
+  if (strategy.hasNotText !== undefined && subtreeContainsText(node, roots, strategy.hasNotText)) {
+    return false;
+  }
+  if (strategy.has !== undefined && !subtreeContainsMatch(node, roots, strategy.has)) {
+    return false;
+  }
+  if (strategy.hasNot !== undefined && subtreeContainsMatch(node, roots, strategy.hasNot)) {
+    return false;
+  }
+  return true;
+}
+
+/** The nodes that count as "inside" a candidate: tree descendants, or — for flat
+ *  hierarchies with no children — nodes contained within the candidate's bounds. */
+function descendantsOf(node: ViewNode, roots: ViewNode[]): ViewNode[] {
+  if (node.children.length > 0) {
+    return flattenNodes(node.children);
+  }
+  return flattenNodes(roots).filter(
+    (n) => n !== node && isContainedWithin(n.bounds, node.bounds),
+  );
+}
+
+/** True if the candidate or any of its descendants contains the given text. */
+function subtreeContainsText(
+  node: ViewNode,
+  roots: ViewNode[],
+  value: string | RegExp,
+): boolean {
+  const candidates = [node, ...descendantsOf(node, roots)];
+  return candidates.some((n) => {
+    const text = n.text ?? n.label ?? n.value ?? '';
+    if (value instanceof RegExp) {
+      return value.test(text);
+    }
+    return text.toLowerCase().includes(value.toLowerCase());
+  });
+}
+
+/** True if a descendant of the candidate matches the inner strategy. Mirrors the
+ *  chain query's tree-first, bounds-fallback resolution. */
+function subtreeContainsMatch(
+  node: ViewNode,
+  roots: ViewNode[],
+  childStrategy: LocatorStrategy,
+): boolean {
+  const treeResults = queryAll(node.children, childStrategy);
+  if (treeResults.length > 0) {
+    return true;
+  }
+  const contained = flattenNodes(roots).filter(
+    (n) => n !== node && isContainedWithin(n.bounds, node.bounds),
+  );
+  return queryAll(contained, childStrategy).length > 0;
 }
 
 /** Flatten a ViewNode tree into a single array. */


### PR DESCRIPTION
Adds `filter()`, `and()`, and `or()` to the native Locator, matching Playwright semantics.

- `filter({ hasText, hasNotText, has, hasNot })` — narrow a locator
- `and(locator)` — intersection of two locators
- `or(locator)` — union of two locators

`has`/`hasNot` match descendants only; `hasText`/`hasNotText` match self + descendants — same as Playwright. Reuses the existing tree-first, bounds-fallback resolution so it works on both nested and flat hierarchies.