### PR TITLE
feat: add device.screenSize() returning width, height, scale

### DIFF
--- a/packages/mobilewright-core/src/device.test.ts
+++ b/packages/mobilewright-core/src/device.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import type {
+  MobilewrightDriver,
+  Orientation,
+  AppInfo,
+  DeviceInfo,
+  ScreenSize,
+} from '@mobilewright/protocol';
+import { Device } from './device.js';
+
+function createMockDriver(screenSize: ScreenSize): MobilewrightDriver {
+  return {
+    connect: async () => ({ deviceId: 'device1', platform: 'ios' as const }),
+    disconnect: async () => {},
+    getViewHierarchy: async () => [],
+    tap: async () => {},
+    doubleTap: async () => {},
+    longPress: async () => {},
+    typeText: async () => {},
+    swipe: async () => {},
+    gesture: async () => {},
+    pressButton: async () => {},
+    screenshot: async () => Buffer.from(''),
+    getScreenSize: async () => screenSize,
+    getOrientation: async () => 'portrait' as Orientation,
+    setOrientation: async () => {},
+    launchApp: async () => {},
+    terminateApp: async () => {},
+    listApps: async () => [] as AppInfo[],
+    getForegroundApp: async () => ({ bundleId: 'com.test' }),
+    installApp: async () => {},
+    uninstallApp: async () => {},
+    listDevices: async () => [] as DeviceInfo[],
+    openUrl: async () => {},
+    startRecording: async () => {},
+    stopRecording: async () => ({}),
+  };
+}
+
+test.describe('Device.screenSize', () => {
+  test('returns the width, height, and scale from the driver', async () => {
+    const driver = createMockDriver({ width: 390, height: 844, scale: 3 });
+    const device = new Device(driver);
+
+    const size = await device.screenSize();
+
+    expect(size).toEqual({ width: 390, height: 844, scale: 3 });
+  });
+});

--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -7,6 +7,7 @@ import type {
   Orientation,
   RecordingOptions,
   RecordingResult,
+  ScreenSize,
   Session,
 } from '@mobilewright/protocol';
 import { Screen } from './screen.js';
@@ -83,6 +84,11 @@ export class Device {
 
   async setOrientation(orientation: Orientation): Promise<void> {
     return this.driver.setOrientation(orientation);
+  }
+
+  /** Screen dimensions and pixel density: { width, height, scale }. */
+  async screenSize(): Promise<ScreenSize> {
+    return this.driver.getScreenSize();
   }
 
   async openUrl(url: string): Promise<void> {


### PR DESCRIPTION
Adds `device.screenSize()` — returns `{ width, height, scale }` from the driver's `getScreenSize()`, which was previously only used internally (screenshot cropping) and not reachable through the public API.

Noun-style name matches Playwright's `page.viewportSize()` convention. Adds `device.test.ts`.