### PR TITLE
feat: upload test report by default unless uploadReport is off

### DIFF
--- a/packages/driver-mobilenext/src/reporter.ts
+++ b/packages/driver-mobilenext/src/reporter.ts
@@ -6,6 +6,7 @@ import { uploadTestResult, extractGitInfoFromReport, type UploadTestResultParams
 const _require = createRequire(import.meta.url);
 
 export interface MobileNextTestResultConfig {
+  /** Upload the test report to mobilenext. 'on' always uploads, 'on-failure' uploads only when a test fails, 'off' disables uploading. Default: 'on'. */
   uploadReport?: 'on' | 'off' | 'on-failure';
   name?: string;
   tags?: string[];

--- a/packages/mobilewright/src/config.test.ts
+++ b/packages/mobilewright/src/config.test.ts
@@ -112,9 +112,12 @@ test('defineConfig does not inject upload reporter when uploadReport is off', ()
   }
 });
 
-test('defineConfig does not inject upload reporter when testResult is absent', () => {
+test('defineConfig injects upload reporter by default when testResult is absent', () => {
   const config = defineConfig({ driver: { type: 'mobilenext', apiKey: 'key' } });
-  expect(config.reporter).toBeUndefined();
+  const reporters = config.reporter as Array<[string, unknown]>;
+  expect(Array.isArray(reporters)).toBe(true);
+  const paths = reporters.map((r) => r[0]);
+  expect(paths.some((p) => String(p).includes('driver-mobilenext'))).toBe(true);
 });
 
 test('defineConfig does not inject upload reporter for mobilecli driver', () => {
@@ -215,9 +218,9 @@ test('defineConfig sets captureGitInfo when mobilenext driver is configured with
   expect(config.captureGitInfo).toEqual({ commit: true });
 });
 
-test('defineConfig does not set captureGitInfo when testResult is absent', () => {
+test('defineConfig sets captureGitInfo by default when testResult is absent', () => {
   const config = defineConfig({ driver: { type: 'mobilenext', apiKey: 'key' } });
-  expect(config.captureGitInfo).toBeUndefined();
+  expect(config.captureGitInfo).toEqual({ commit: true });
 });
 
 test('defineConfig accepts mobilenext driver with testResult config', () => {

--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -167,7 +167,7 @@ function injectUploadReporter(config: MobilewrightConfig): MobilewrightConfig {
   }
   const mobileNextDriver = driver as DriverConfigMobileNext;
   const testResult = mobileNextDriver.testResult;
-  if (!testResult || testResult.uploadReport === 'off') {
+  if (testResult?.uploadReport === 'off') {
     return config;
   }
 
@@ -187,7 +187,7 @@ function injectUploadReporter(config: MobilewrightConfig): MobilewrightConfig {
       [uploadReporterPath, {
         apiKey: mobileNextDriver.apiKey ?? '',
         jsonResultsPath,
-        testResult: mobileNextDriver.testResult,
+        testResult: mobileNextDriver.testResult ?? {},
         uploadTimeout: mobileNextDriver.uploadTimeout,
       }],
     ],


### PR DESCRIPTION
We successfully passed testing. Things are stable. We can change to opt-out instead of opt-in.

## Behavior

| Config | Upload |
|---|---|
| no `testResult` block | uploads always (**changed** — was no upload) |
| `testResult` set, `uploadReport` omitted | uploads always |
| `uploadReport: 'on'` | uploads always |
| `uploadReport: 'on-failure'` | uploads on failure |
| `uploadReport: 'off'` | no upload |
