### PR TITLE
fix: tolerate dump without elements

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -349,7 +349,7 @@ export class MobilecliDriver implements MobilewrightDriver {
 
   async getViewHierarchy(): Promise<ViewNode[]> {
     const result = await this.call<MobilecliUIDumpResponse>('device.dump.ui');
-    return result.elements.map(elementToViewNode);
+    return (result?.elements ?? []).map(elementToViewNode);
   }
 
   async tap(x: number, y: number): Promise<void> {


### PR DESCRIPTION
**Problem**: `result.elements.map(...)` throws when the dump has no elements; because it throws inside `getViewHierarchy()`, the auto-wait retry loop can't catch it, so a `toBeVisible` assertion aborts the test. Happens mid-transition (app still launching).

**Fix**: `(result?.elements ?? []).map(...)` → empty tree → assertion retries instead of crashing. Shown with the actual before/after.

**Notes**: 
* no behavior change for the normal case
* surfaced during a launch → assert flow. 
* `npm run lint` passes.