### PR TITLE
docs: update changelog for 0.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.0.45] (2026-06-15)
+* Feat(Locator): `locator.clear()` empties a text field, and `fill()` now auto-clears before typing ([#195](https://github.com/mobile-next/mobilewright/pull/195))
+* Feat(Agent): automatically update the agent on `install` when versions differ
+* Feat(Android): add placeholder field to Android `dump ui`
+* Fix(Android): restore missing Android EditText if it had no value, no hint, no id (but was clickable)
+* Feat: return installed app metadata from `apps install`
+* Feat(Android): Android `list apps` now includes version and versionCode
+* Fix: scale press-keys RPC timeout by key count
+* Fix(iOS): match agent bundle id by suffix to support re-signed runner
+* Chore: update npm packages for security ([#193](https://github.com/mobile-next/mobilewright/pull/193))
+* Chore: update bundled mobilecli to 0.3.84 ([#199](https://github.com/mobile-next/mobilewright/pull/199))
+
 ## [0.0.44] (2026-06-12)
 * Feat: add `activity` to `LaunchOptions` ([#182](https://github.com/mobile-next/mobilewright/pull/182))
 * Feat(driver-mobilenext): upload test report by default unless `uploadReport` is off ([#188](https://github.com/mobile-next/mobilewright/pull/188))


### PR DESCRIPTION
Release notes for 0.0.45.

## Changes since v0.0.44
- `locator.clear()` and `fill()` auto-clear (#195)
- mobilecli bumped to 0.3.84 (#199), which brings agent install/uninstall improvements, Android `dump ui` placeholder + clickable/checkable element fixes, installed-app metadata, and re-signed runner support
- npm security updates (#193)

Omitted ci (#194) and docs (#192) commits as not user-facing.