### PR TITLE
feat: device-level settings with animations toggle

### DIFF
--- a/docs/src/test/fixtures.md
+++ b/docs/src/test/fixtures.md
@@ -50,6 +50,7 @@ You can override the following settings per-test or per-project, in addition to 
 | `bundleId` | `string` | App bundle identifier |
 | `installApps` | `string \| string[]` | App paths (APK/IPA) to install before launching |
 | `autoAppLaunch` | `boolean` | Automatically launch the app after connecting. Default: `true` |
+| `animations` | `'on' \| 'off'` | Toggle system animations on the device for stable screenshots (set under `use`). If omitted, then no change — the device is left as-is. |
 | `viewTree` | `'on-failure' \| 'off'` | Attach the accessibility view tree as JSON to the report when a test fails. Default: `'off'` |
 
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,9 +2456,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/driver-mobilecli/src/driver.test.ts
+++ b/packages/driver-mobilecli/src/driver.test.ts
@@ -351,3 +351,16 @@ test.describe('MobilecliDriver.clearText()', () => {
     ]);
   });
 });
+
+test.describe('MobilecliDriver.applyDeviceSettings()', () => {
+  test('sends device.settings.apply with the settings and deviceId', async () => {
+    const driver = createDriverWithSession({ platform: 'android' });
+    const calls = recordRpc(driver, { 'device.settings.apply': {} });
+
+    await driver.applyDeviceSettings({ animations: 'off' });
+
+    expect(calls).toEqual([
+      { method: 'device.settings.apply', params: { deviceId: SIMULATOR_DEVICE_ID, animations: 'off' } },
+    ]);
+  });
+});

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -6,6 +6,7 @@ import type {
   Bounds,
   ConnectionConfig,
   DeviceInfo,
+  DeviceSettings,
   DeviceState,
   DeviceType,
   GestureSequence,
@@ -343,6 +344,10 @@ export class MobilecliDriver implements MobilewrightDriver {
   async disconnect(): Promise<void> {
     await this.requireSession().rpc.disconnect();
     this.session = null;
+  }
+
+  async applyDeviceSettings(settings: DeviceSettings): Promise<void> {
+    await this.call('device.settings.apply', { ...settings });
   }
 
   // ─── Element Operations ──────────────────────────────────────

--- a/packages/mobilewright-core/src/device.test.ts
+++ b/packages/mobilewright-core/src/device.test.ts
@@ -49,3 +49,26 @@ test.describe('Device.screenSize', () => {
     expect(size).toEqual({ width: 390, height: 844, scale: 3 });
   });
 });
+
+test.describe('Device.applyDeviceSettings', () => {
+  test('forwards the settings to the driver', async () => {
+    const driver = createMockDriver({ width: 390, height: 844, scale: 3 });
+    const applied: unknown[] = [];
+    driver.applyDeviceSettings = async (settings) => {
+      applied.push(settings);
+    };
+    const device = new Device(driver);
+
+    await device.applyDeviceSettings({ animations: 'off' });
+
+    expect(applied).toEqual([{ animations: 'off' }]);
+  });
+
+  test('no-ops when the driver does not support device settings', async () => {
+    const driver = createMockDriver({ width: 390, height: 844, scale: 3 });
+    expect(driver.applyDeviceSettings).toBeUndefined();
+    const device = new Device(driver);
+
+    await expect(device.applyDeviceSettings({ animations: 'off' })).resolves.toBeUndefined();
+  });
+});

--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -2,6 +2,7 @@ import createDebug from 'debug';
 import type {
   AppInfo,
   ConnectionConfig,
+  DeviceSettings,
   LaunchOptions,
   MobilewrightDriver,
   Orientation,
@@ -60,6 +61,15 @@ export class Device {
 
   async disconnect(): Promise<void> {
     await this.driver.disconnect();
+  }
+
+  /**
+   * Apply device-level settings (animations, etc.) to the connected device.
+   * No-ops when the driver doesn't support it. Fire-and-forget: settings are
+   * not restored on disconnect.
+   */
+  async applyDeviceSettings(settings: DeviceSettings): Promise<void> {
+    await this.driver.applyDeviceSettings?.(settings);
   }
 
   /** Full cleanup: disconnect + run any registered cleanup callbacks. */

--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -21,6 +21,8 @@ export interface MobilewrightUseOptions {
   bundleId?: string;
   /** App paths (APK/IPA) to install for this project. Overrides top-level installApps. */
   installApps?: string | string[];
+  /** System animations on the device: 'on' or 'off'. If omitted, the device is left unchanged. */
+  animations?: 'on' | 'off';
   /** Default timeout for locator actions (tap, fill, etc.) in ms. Default: 5000. */
   actionTimeout?: number;
   /** Timeout waiting for the app to reach foreground after launch, in ms. Default: 20000. */

--- a/packages/mobilewright/src/launchers.ts
+++ b/packages/mobilewright/src/launchers.ts
@@ -1,4 +1,4 @@
-import type { Platform, DeviceInfo, DeviceType, MobilewrightDriver } from '@mobilewright/protocol';
+import type { Platform, DeviceInfo, DeviceType, DeviceSettings, MobilewrightDriver } from '@mobilewright/protocol';
 import { Device } from '@mobilewright/core';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
 import { MobileNextDriver } from '@mobilewright/driver-mobilenext';
@@ -20,6 +20,7 @@ export interface LaunchOptions {
   expectTimeout?: number;
   appLaunchTimeout?: number;
   installTimeout?: number;
+  animations?: 'on' | 'off';
 }
 
 interface PlatformLauncher {
@@ -38,6 +39,7 @@ export interface ConnectDeviceParams {
   expectTimeout?: number;
   appLaunchTimeout?: number;
   installTimeout?: number;
+  deviceSettings?: DeviceSettings;
 }
 
 export interface FindDeviceParams {
@@ -78,6 +80,12 @@ export async function connectDevice(params: ConnectDeviceParams): Promise<Device
     deviceType: params.deviceType,
     timeout: params.timeout,
   });
+
+  const settings = params.deviceSettings;
+  if (settings && Object.values(settings).some((value) => value !== undefined)) {
+    await device.applyDeviceSettings(settings);
+  }
+
   return device;
 }
 
@@ -138,6 +146,7 @@ function createLauncher(platform: Platform): PlatformLauncher {
         expectTimeout: opts.expectTimeout,
         appLaunchTimeout: opts.appLaunchTimeout,
         installTimeout: opts.installTimeout,
+        deviceSettings: { animations: opts.animations },
       });
 
       if (serverProcess) {

--- a/packages/protocol/src/driver.ts
+++ b/packages/protocol/src/driver.ts
@@ -2,6 +2,7 @@ import type {
   AppInfo,
   ConnectionConfig,
   DeviceInfo,
+  DeviceSettings,
   GestureSequence,
   HardwareButton,
   LaunchOptions,
@@ -52,6 +53,14 @@ export interface MobilewrightDriver {
   connect(config: ConnectionConfig): Promise<Session>;
   /** End the active session and release the device. */
   disconnect(): Promise<void>;
+
+  // Device settings
+  /**
+   * Apply device-level settings (animations, etc.) to the connected device.
+   * Optional — drivers that don't support it omit it and callers no-op.
+   * Fire-and-forget: settings are not restored on disconnect.
+   */
+  applyDeviceSettings?(settings: DeviceSettings): Promise<void>;
 
   // UI hierarchy
   /** Fetch the current on-screen view hierarchy as a forest of nodes. */

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -87,6 +87,19 @@ export interface Session {
   platform: Platform;
 }
 
+// ─── Device Settings ─────────────────────────────────────────────
+
+/**
+ * Device-level settings applied to the connected device after connect.
+ *
+ * Applied as a partial update (PATCH semantics): only the keys provided are
+ * touched. Fire-and-forget — settings are not restored on disconnect.
+ */
+export interface DeviceSettings {
+  /** System animations on the device. If omitted, the device is left unchanged. */
+  animations?: 'on' | 'off';
+}
+
 // ─── Input ───────────────────────────────────────────────────────
 
 export type SwipeDirection = 'up' | 'down' | 'left' | 'right';

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -145,6 +145,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
       expectTimeout: merged.expect?.timeout,
       appLaunchTimeout: merged.use?.appLaunchTimeout,
       installTimeout: merged.use?.installTimeout,
+      deviceSettings: { animations: merged.use?.animations },
     });
     debug('connected to device %s', handle.deviceId);
 


### PR DESCRIPTION
## Summary

Introduces a generic device-settings mechanism so config can declare device-level options that the **driver** applies (no framework-side adb). First setting: `animations`.

```ts
export default defineConfig({
  use: {
    animations: 'off',   // 'on' | 'off' | (omit = leave the device unchanged)
  },
});
```

| Value | Behavior |
|-------|----------|
| omitted | no RPC at all — whatever's on the device stays |
| `'off'` | disable animations |
| `'on'` | enable animations |

## How it flows

`use.animations` → `DeviceSettings { animations }` → `Device.applyDeviceSettings()` → `MobilecliDriver` RPC `device.settings.apply`. Applied inside `connectDevice()` (after connect, before app launch) — the single chokepoint both the test fixture and the manual `launch()` API funnel through.

- `applyDeviceSettings?` is **optional** on the `MobilewrightDriver` protocol, so the cloud `mobilenext` driver simply omits it and the call no-ops.
- Fire-and-forget: settings are not restored on disconnect.

## Requires

The mobilecli RPC handler: **mobile-next/mobilecli#287** (land that first). On iOS, mobilecli treats `animations` as a successful no-op, so iOS runs are unaffected.

## Test plan

- [x] `npm run build` && `npm run lint`
- [x] `npx playwright test` — full unit suite (431 passed), incl. new tests:
  - `Device.applyDeviceSettings` delegates / no-ops when the driver lacks it
  - `MobilecliDriver.applyDeviceSettings` issues `device.settings.apply` with the expected payload
- [ ] e2e on a real Android emulator with `animations: 'off'`