### PR TITLE
fix(core): dismiss keyboard after Locator.fill()

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -423,10 +423,18 @@ export class MobilecliDriver implements MobilewrightDriver {
 
   async dismissKeyboard(): Promise<void> {
     const platform = this.requireSession().platform;
+
+    // Only dismiss if a text input is currently focused — otherwise the
+    // dismiss action (BACK / Done) could navigate back or submit a form.
+    const roots = await this.getViewHierarchy();
+    if (!focusedTextInputExists(roots)) {
+      return;
+    }
+
     if (platform === 'android') {
-      await this.pressButton('BACK');
+      await this.pressKeys(['back']);
     } else {
-      await this.pressKeys(['return']);
+      await this.pressKeys(['Done']);
     }
   }
 
@@ -629,4 +637,22 @@ export class MobilecliDriver implements MobilewrightDriver {
     if (!this.session) throw new Error('No active session. Call connect() first.');
     return this.session;
   }
+}
+
+/** Recursively scan for a focused text-input element. Returns true when found. */
+function focusedTextInputExists(nodes: ViewNode[]): boolean {
+  for (const node of nodes) {
+    if (node.isFocused && isTextInputType(node.type)) {
+      return true;
+    }
+    if (node.children.length > 0 && focusedTextInputExists(node.children)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isTextInputType(type: string): boolean {
+  const lower = type.toLowerCase();
+  return lower.includes('text') || lower.includes('edit') || lower.includes('search');
 }

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -421,6 +421,15 @@ export class MobilecliDriver implements MobilewrightDriver {
     await this.call('device.io.button', { button });
   }
 
+  async dismissKeyboard(): Promise<void> {
+    const platform = this.requireSession().platform;
+    if (platform === 'android') {
+      await this.pressButton('BACK');
+    } else {
+      await this.pressKeys(['return']);
+    }
+  }
+
   // ─── Screen Operations ───────────────────────────────────────
 
   async screenshot(opts?: ScreenshotOptions): Promise<Buffer> {

--- a/packages/driver-mobilenext/src/driver.ts
+++ b/packages/driver-mobilenext/src/driver.ts
@@ -414,6 +414,15 @@ export class MobileNextDriver implements MobilewrightDriver {
     await this.call('device.io.button', { button });
   }
 
+  async dismissKeyboard(): Promise<void> {
+    const platform = this.requireSession().platform;
+    if (platform === 'android') {
+      await this.pressButton('BACK');
+    } else {
+      await this.pressKeys(['return']);
+    }
+  }
+
   // ─── Screen ─────────────────────────────────────────────────
 
   async screenshot(opts?: ScreenshotOptions): Promise<Buffer> {

--- a/packages/driver-mobilenext/src/driver.ts
+++ b/packages/driver-mobilenext/src/driver.ts
@@ -416,10 +416,18 @@ export class MobileNextDriver implements MobilewrightDriver {
 
   async dismissKeyboard(): Promise<void> {
     const platform = this.requireSession().platform;
+
+    // Only dismiss if a text input is currently focused — otherwise the
+    // dismiss action (BACK / Done) could navigate back or submit a form.
+    const roots = await this.getViewHierarchy();
+    if (!focusedTextInputExists(roots)) {
+      return;
+    }
+
     if (platform === 'android') {
-      await this.pressButton('BACK');
+      await this.pressKeys(['back']);
     } else {
-      await this.pressKeys(['return']);
+      await this.pressKeys(['Done']);
     }
   }
 
@@ -602,4 +610,22 @@ export class MobileNextDriver implements MobilewrightDriver {
     }
     return this.session;
   }
+}
+
+/** Recursively scan for a focused text-input element. Returns true when found. */
+function focusedTextInputExists(nodes: ViewNode[]): boolean {
+  for (const node of nodes) {
+    if (node.isFocused && isTextInputType(node.type)) {
+      return true;
+    }
+    if (node.children.length > 0 && focusedTextInputExists(node.children)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isTextInputType(type: string): boolean {
+  const lower = type.toLowerCase();
+  return lower.includes('text') || lower.includes('edit') || lower.includes('search');
 }

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -180,10 +180,14 @@ export class Locator {
     return this._step('locator.clear()', () => this._tapAndClear(opts?.timeout));
   }
 
-  async fill(text: string, opts?: { timeout?: number }): Promise<void> {
+  async fill(text: string, opts?: { timeout?: number; dismissKeyboard?: boolean }): Promise<void> {
     return this._step(`locator.fill(${JSON.stringify(text)})`, async () => {
       await this._tapAndClear(opts?.timeout);
       await this.driver.typeText(text);
+      const dismiss = opts?.dismissKeyboard ?? true;
+      if (dismiss) {
+        await this.driver.dismissKeyboard?.();
+      }
     });
   }
 

--- a/packages/protocol/src/driver.ts
+++ b/packages/protocol/src/driver.ts
@@ -85,6 +85,8 @@ export interface MobilewrightDriver {
   gesture(gestures: GestureSequence): Promise<void>;
   /** Press a hardware button (e.g. home, back, volume). */
   pressButton(button: HardwareButton): Promise<void>;
+  /** Dismiss the soft keyboard if it is currently open. Optional — drivers that don't support it omit it. */
+  dismissKeyboard?(): Promise<void>;
 
   // Screen
   /** Capture a screenshot of the device screen as a PNG buffer. */


### PR DESCRIPTION

## Related issues

This PR implements:

- **Feature request: [Automatically dismiss the soft keyboard after `Locator.fill()` on mobile #154](https://github.com/mobile-next/mobilewright/issues/154)** - full design discussion for this change

## Summary

`Locator.fill()` now automatically dismisses the soft keyboard after text entry on mobile, making follow-up interactions (especially taps on elements below the focused input) reliable without requiring an explicit keyboard dismissal step.

## The problem this solves

After calling `.fill()` on an input, the soft keyboard stays open. On Android this can cover interactive elements lower on the screen, such as submit buttons. The next `.tap()` may then hit the keyboard area or keep focus on the currently active input instead of activating the intended control.

The existing workaround (`screen.goBack()` after every fill) adds boilerplate and is easy to forget, leading to flaky tests.

## What this PR does

**`packages/protocol/src/driver.ts`**

- Added optional `dismissKeyboard?(): Promise<void>` method to the `MobilewrightDriver` interface. Optional so drivers without keyboard support can simply omit it.

**`packages/driver-mobilecli/src/driver.ts`** and **`packages/driver-mobilenext/src/driver.ts`**

- Implemented `dismissKeyboard()` with a safety check:
  - Scans the view hierarchy for a focused text input before dismissing
  - Returns early if none is found, preventing accidental navigation
  - **Android**: sends `back` key event (keyboard-specific, not navigation)
  - **iOS**: sends `Done` key event (standard keyboard dismiss action)

**`packages/mobilewright-core/src/locator.ts`**

- `Locator.fill()` now calls `driver.dismissKeyboard?.()` after `driver.typeText()` completes, enabled by default.
- Added per-call opt-out: `fill('text', { dismissKeyboard: false })` for users who want the keyboard to remain open.

**`e2e/src/android/facebook.keyboard.test.ts`**

- Updated test title and comments to reflect the new auto-dismiss behavior.
- Removed the `wait(1000)` and commented-out `goBack()` workaround.

## Test plan

- [x] `npm run build` - clean (`tsc -b`)
- [x] `npm run lint` - clean (`tsc --noEmit && eslint .`)
- [x] `npx playwright test packages/mobilewright-core/src/locator.test.ts` - **49/49 passing**
- [x] Real-device E2E (Android/Facebook login):
  - [x] **Default behavior** (`dismissKeyboard: true`): keyboard dismissed -> tap succeeds
  - [x] **Opted out** (`dismissKeyboard: false`): keyboard stays open -> tap fails -> confirms fix works
- [ ] **iOS not tested** - the iOS path (`pressKeys(['Done'])`) was not verified on a real device. The reviewer should confirm this dismisses the keyboard correctly on iOS before merging.

## Backwards compatibility

| Change | Compat |
|---|---|
| `dismissKeyboard?()` on driver interface | Additive - optional method, existing drivers are unaffected |
| `dismissKeyboard()` with focused-input check | Safer - only acts when a text input is focused |
| `fill()` auto-dismisses keyboard | Behavioral change - opt-out per-call via `{ dismissKeyboard: false }` |
| `fill()` signature widened with `dismissKeyboard?: boolean` | Additive - existing calls continue to compile unchanged |

## Files changed

```
packages/protocol/src/driver.ts                 |  1 +
packages/driver-mobilecli/src/driver.ts          | 32 +++++++++++++++++++++++-
packages/driver-mobilenext/src/driver.ts         | 32 +++++++++++++++++++++++-
packages/mobilewright-core/src/locator.ts        |  6 ++++-
e2e/src/android/facebook.keyboard.test.ts       | 13 +++++-----
5 files changed, 72 insertions(+), 12 deletions(-)
```