### PR TITLE
fix(test): merge project-level use into config for actionTimeout and other options

### DIFF
--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -89,11 +89,14 @@ export const test = base.extend<MobilewrightTestFixtures>({
 
   device: async ({ platform, deviceName, bundleId, autoAppLaunch, installApps }, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
+    const project = config.projects?.find(p => p.name === testInfo.project.name);
+    const projectUse = { ...config.use, ...project?.use };
     const merged = {
       ...config,
       ...(platform && { platform }),
       ...(deviceName && { deviceName }),
       ...(installApps !== undefined && { installApps }),
+      use: projectUse,
     };
     
     if (merged.platform !== 'ios' && merged.platform !== 'android') {


### PR DESCRIPTION
The device fixture only reads top-level `config.use`, silently ignoring options set inside `config.projects[].use` like `actionTimeout`, `appLaunchTimeout`, `installTimeout`, and `animations`.

Finds the matching project by name via `testInfo.project.name` and merges its `use` into the top-level `use` before passing to `connectDevice`.