### PR TITLE
fix(core): scrollIntoViewIfNeeded swipes wrong direction when element bottom partially off-screen

### DIFF
--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -669,7 +669,7 @@ test.describe('Locator', () => {
       const locator = new Locator(driver, { kind: 'label', value: 'Far' });
       await locator.scrollIntoViewIfNeeded({ maxSwipes: 5 });
 
-      // centerY of belowBounds = 900 + 22 = 922 > 844, so swipeDirectionToReveal returns 'up'
+      // bottomY of belowBounds = 900 + 44 = 944 > 844, so swipeDirectionToReveal returns 'up'
       expect(driver._tracker.swipeCalls[0]).toEqual(['up']);
     });
 
@@ -689,7 +689,7 @@ test.describe('Locator', () => {
       const locator = new Locator(driver, { kind: 'label', value: 'Far' });
       await locator.scrollIntoViewIfNeeded({ maxSwipes: 5 });
 
-      // centerY of aboveBounds = -200 + 22 = -178, not > 844, so swipeDirectionToReveal returns 'down'
+      // bottomY of aboveBounds = -200 + 44 = -156, not > 844, so swipeDirectionToReveal returns 'down'
       expect(driver._tracker.swipeCalls[0]).toEqual(['down']);
     });
 
@@ -701,6 +701,28 @@ test.describe('Locator', () => {
       const locator = new Locator(driver, { kind: 'label', value: 'Far' });
 
       await expect(locator.scrollIntoViewIfNeeded({ maxSwipes: 1 })).rejects.toThrow(LocatorError);
+    });
+
+    test('swipes up when element bottom exceeds viewport even when center is within viewport', async () => {
+      // Edge case: element center (822) is within viewport but bottom (866) exceeds screen height (844)
+      const partiallyBelowBounds = { x: 0, y: 822, width: 390, height: 44 };
+      const inViewBounds = { x: 0, y: 400, width: 390, height: 44 };
+      const belowTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: partiallyBelowBounds })] })];
+      const inViewTree: ViewNode[] = [node({ type: 'Window', children: [node({ type: 'Button', label: 'Far', bounds: inViewBounds })] })];
+
+      const driver = createMockDriver(belowTree);
+      let callCount = 0;
+      driver.getViewHierarchy = async () => {
+        callCount++;
+        return callCount >= 2 ? inViewTree : belowTree;
+      };
+
+      const locator = new Locator(driver, { kind: 'label', value: 'Far' });
+      await locator.scrollIntoViewIfNeeded({ maxSwipes: 5 });
+
+      // Old code used centerY (822), which is not > 844, so it returned 'down' (wrong).
+      // Fixed code uses bottomY (866), which is > 844, so it returns 'up' (correct).
+      expect(driver._tracker.swipeCalls[0]).toEqual(['up']);
     });
   });
 

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -481,12 +481,12 @@ function isWithinViewport(bounds: Bounds, screen: ScreenSize): boolean {
 }
 
 function swipeDirectionToReveal(bounds: Bounds, screen: ScreenSize): SwipeDirection {
-  const centerY = bounds.y + bounds.height / 2;
-  // Element is below the viewport → swipe up to reveal it
-  if (centerY > screen.height) {
+  const bottomY = bounds.y + bounds.height;
+  // Element extends below the viewport → swipe up (scroll down) to reveal it
+  if (bottomY > screen.height) {
     return 'up';
   }
-  // Element is above the viewport → swipe down to reveal it
+  // Element is above the viewport → swipe down (scroll up) to reveal it
   return 'down';
 }
 


### PR DESCRIPTION
`swipeDirectionToReveal` used `centerY` to determine scroll direction. When an element's center was within the viewport but its bottom edge extended past the screen, it returned `'down'` (scroll up), pushing the element further out of view.

Now uses `bottomY` instead: if the trailing edge extends past the screen bottom, we correctly swipe `'up'` (scroll down) to bring it into view.

Includes a test for the edge case: centerY (822) <= screen.height (844) but bottomY (866) > screen.height.