### PR TITLE
Adds initial support for Sauce Labs as a driver for Mobilewright. 

### DIFF
--- a/e2e/mobilewright.config.ts
+++ b/e2e/mobilewright.config.ts
@@ -15,11 +15,20 @@ function resolveDriver(): DriverConfig {
         apiKey: process.env['MOBILENEXT_API_KEY'],
       };
 
-    case 'saucelabs':
+    case 'saucelabs': {
+      if (!process.env['SAUCE_USERNAME'] || !process.env['SAUCE_ACCESS_KEY']) {
+        throw new Error('SAUCE_USERNAME and SAUCE_ACCESS_KEY are required for saucelabs driver');
+      }
+      const region = process.env['SAUCE_REGION'] ?? 'us-west-1';
+      const validRegions = ['us-west-1', 'eu-central-1', 'us-east-4'] as const;
+      if (!validRegions.includes(region as typeof validRegions[number])) {
+        throw new Error(`Invalid SAUCE_REGION: ${region}. Valid values: ${validRegions.join(', ')}`);
+      }
       return {
         type: 'saucelabs',
-        region: (process.env['SAUCE_REGION'] ?? 'us-west-1') as 'us-west-1' | 'eu-central-1' | 'us-east-4',
+        region: region as typeof validRegions[number],
       };
+    }
 
     case 'mobilecli':
       return { type: 'mobilecli' };

--- a/e2e/mobilewright.config.ts
+++ b/e2e/mobilewright.config.ts
@@ -10,35 +10,46 @@ function resolveDriver(): DriverConfig {
       if (!process.env['MOBILENEXT_API_KEY']) {
         throw new Error('MOBILENEXT_API_KEY is required for mobilenext driver');
       }
-      
       return {
         type: 'mobilenext',
         apiKey: process.env['MOBILENEXT_API_KEY'],
       };
 
-    case 'mobilecli': 
-    return { type: 'mobilecli' };
+    case 'saucelabs':
+      return {
+        type: 'saucelabs',
+        region: (process.env['SAUCE_REGION'] ?? 'us-west-1') as 'us-west-1' | 'eu-central-1' | 'us-east-4',
+      };
+
+    case 'mobilecli':
+      return { type: 'mobilecli' };
 
     default:
-      throw new Error(`Unknown driver: ${name}. Use ['mobilecli' or 'mobilenext']`);
+      throw new Error(`Unknown driver: ${name}. Use 'mobilecli', 'mobilenext', or 'saucelabs'`);
   }
 }
+
+const driver = process.env['MOBILEWRIGHT_DRIVER'] ?? 'mobilecli';
+const isSauce = driver === 'saucelabs';
+const sauceUse = isSauce
+  ? { video: 'on' as const, screenshot: 'on' as const }
+  : {};
 
 const config: MobilewrightConfig = defineConfig({
   testDir: './src',
   testMatch: '**/*.test.ts',
   retries: 0,
-  timeout: 60_000,
+  timeout: isSauce ? 400_000 : 60_000,
+  reporter: 'html',
 
-  // supports mobilecli and mobilenext drivers
+  // supports mobilecli, mobilenext, and Sauce drivers
   driver: resolveDriver(),
 
   // one project per platform. Tests under src/conformance run on both; tests
-  // under src/ios or src/android are platform-specific and only run on that
-  // project (each project ignores the other platform's directory).
+  // under src/ios or src/android are platform-specific and only run on the matching project.
   projects: [
-    { name: 'ios', use: { platform: 'ios' }, testIgnore: '**/android/**' },
-    { name: 'android', use: { platform: 'android' }, testIgnore: '**/ios/**' },
+    { name: 'ios', use: { platform: 'ios', ...sauceUse }, testIgnore: '**/android/**' },
+    { name: 'android', use: { platform: 'android', ...sauceUse }, testIgnore: '**/ios/**' },
   ],
 
   // filter used devices with regexp

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test:mobilecli": "MOBILEWRIGHT_DRIVER=mobilecli node ../packages/mobilewright/dist/cli.js test",
     "test:mobilenext": "MOBILEWRIGHT_DRIVER=mobilenext node ../packages/mobilewright/dist/cli.js test",
+    "test:saucelabs": "MOBILEWRIGHT_DRIVER=saucelabs node ../packages/mobilewright/dist/cli.js test",
     "test:playwright": "playwright test"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,6 +1129,10 @@
       "resolved": "packages/driver-mobilenext",
       "link": true
     },
+    "node_modules/@mobilewright/driver-saucelabs": {
+      "resolved": "packages/driver-saucelabs",
+      "link": true
+    },
     "node_modules/@mobilewright/protocol": {
       "resolved": "packages/protocol",
       "link": true
@@ -1171,6 +1175,16 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -1485,6 +1499,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -2542,6 +2565,25 @@
         "node": ">=18"
       }
     },
+    "packages/driver-saucelabs": {
+      "name": "@mobilewright/driver-saucelabs",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mobilewright/protocol": "*",
+        "adm-zip": "^0.5.16",
+        "debug": "^4.4.3",
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/adm-zip": "^0.5.7",
+        "@types/debug": "^4.1.13",
+        "@types/ws": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "packages/mobilewright": {
       "version": "0.0.1",
       "license": "Apache-2.0",
@@ -2549,6 +2591,7 @@
         "@mobilewright/core": "^0.0.1",
         "@mobilewright/driver-mobilecli": "^0.0.1",
         "@mobilewright/driver-mobilenext": "^0.0.1",
+        "@mobilewright/driver-saucelabs": "*",
         "@mobilewright/protocol": "^0.0.1",
         "commander": "^14.0.3",
         "debug": "^4.4.3",

--- a/packages/driver-saucelabs/package.json
+++ b/packages/driver-saucelabs/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@mobilewright/protocol": "*",
+    "@mobilewright/protocol": "^0.0.1",
     "adm-zip": "^0.5.16",
     "debug": "^4.4.3",
     "ws": "^8.18.0"

--- a/packages/driver-saucelabs/package.json
+++ b/packages/driver-saucelabs/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@mobilewright/driver-saucelabs",
+  "version": "0.0.1",
+  "description": "Sauce Labs Real Device Access driver for Mobilewright",
+  "homepage": "https://mobilewright.dev",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "prepublishOnly": "tsc -b"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mobile-next/mobilewright.git",
+    "directory": "packages/driver-saucelabs"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@mobilewright/protocol": "*",
+    "adm-zip": "^0.5.16",
+    "debug": "^4.4.3",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
+    "@types/debug": "^4.1.13",
+    "@types/ws": "^8.5.0"
+  }
+}

--- a/packages/driver-saucelabs/src/companion-socket.test.ts
+++ b/packages/driver-saucelabs/src/companion-socket.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { CompanionSocket } from './companion-socket.js';
+
+// Exercise the private message parser without opening a real WebSocket.
+function sendMessage(socket: CompanionSocket, msg: unknown): void {
+  (socket as any).handleMessage(JSON.stringify(msg));
+}
+
+function createSocket() {
+  return new CompanionSocket('wss://fake', 'user', 'key');
+}
+
+// ─── Orientation finish ───────────────────────────────────────────────────────
+
+test('calls handler with LANDSCAPE on device.orientation.finish LANDSCAPE', () => {
+  const socket = createSocket();
+  let received: string | undefined;
+  socket.onOrientationFinish((o) => { received = o; });
+
+  sendMessage(socket, { type: 'device.orientation.finish', value: { orientation: 'LANDSCAPE' } });
+
+  expect(received).toBe('LANDSCAPE');
+});
+
+test('calls handler with PORTRAIT on device.orientation.finish PORTRAIT', () => {
+  const socket = createSocket();
+  let received: string | undefined;
+  socket.onOrientationFinish((o) => { received = o; });
+
+  sendMessage(socket, { type: 'device.orientation.finish', value: { orientation: 'PORTRAIT' } });
+
+  expect(received).toBe('PORTRAIT');
+});
+
+test('normalises lowercase orientation value to uppercase', () => {
+  const socket = createSocket();
+  let received: string | undefined;
+  socket.onOrientationFinish((o) => { received = o; });
+
+  sendMessage(socket, { type: 'device.orientation.finish', value: { orientation: 'landscape' } });
+
+  expect(received).toBe('LANDSCAPE');
+});
+
+test('calls the latest registered handler, not a previous one', () => {
+  const socket = createSocket();
+  const results: string[] = [];
+
+  socket.onOrientationFinish(() => results.push('first'));
+  socket.onOrientationFinish((o) => results.push(`second:${o}`));
+
+  sendMessage(socket, { type: 'device.orientation.finish', value: { orientation: 'LANDSCAPE' } });
+
+  expect(results).toEqual(['second:LANDSCAPE']);
+});
+
+// ─── Ignored events ───────────────────────────────────────────────────────────
+
+test('does not call handler for device.orientation.start events', () => {
+  const socket = createSocket();
+  let called = false;
+  socket.onOrientationFinish(() => { called = true; });
+
+  sendMessage(socket, { type: 'device.orientation.start', value: { orientation: 'LANDSCAPE' } });
+
+  expect(called).toBe(false);
+});
+
+test('does not call handler for unrelated event types', () => {
+  const socket = createSocket();
+  let called = false;
+  socket.onOrientationFinish(() => { called = true; });
+
+  sendMessage(socket, { type: 'device.log.message', value: { message: 'hello' } });
+
+  expect(called).toBe(false);
+});
+
+// ─── Robustness ───────────────────────────────────────────────────────────────
+
+test('silently ignores malformed JSON', () => {
+  const socket = createSocket();
+  expect(() => {
+    (socket as any).handleMessage('not valid json {{{');
+  }).not.toThrow();
+});
+
+test('silently ignores orientation.finish with missing value', () => {
+  const socket = createSocket();
+  let called = false;
+  socket.onOrientationFinish(() => { called = true; });
+
+  sendMessage(socket, { type: 'device.orientation.finish' }); // no value field
+
+  expect(called).toBe(false);
+});

--- a/packages/driver-saucelabs/src/companion-socket.ts
+++ b/packages/driver-saucelabs/src/companion-socket.ts
@@ -1,0 +1,87 @@
+import createDebug from 'debug';
+import WebSocket from 'ws';
+
+const debug = createDebug('mw:driver-saucelabs:companion');
+
+const WS_CLOSE_NORMAL = 1000;
+
+type OrientationFinishHandler = (orientation: 'PORTRAIT' | 'LANDSCAPE') => void;
+
+/** WebSocket connection to the Sauce Labs events channel, used to receive device lifecycle events such as orientation changes. */
+export class CompanionSocket {
+  private ws: WebSocket | null = null;
+  private readonly authHeader: string;
+  private orientationHandler: OrientationFinishHandler | null = null;
+
+  constructor(
+    private readonly url: string,
+    username: string,
+    accessKey: string,
+  ) {
+    this.authHeader = `Basic ${Buffer.from(`${username}:${accessKey}`).toString('base64')}`;
+  }
+
+  /** Opens the WebSocket and begins listening for device events. */
+  async connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(this.url, {
+        headers: { Authorization: this.authHeader },
+      });
+
+      ws.on('open', () => {
+        debug('companion socket connected');
+        this.ws = ws;
+        resolve();
+      });
+
+      ws.on('error', (err) => {
+        debug('companion socket error: %s', err.message);
+        if (!this.ws) {
+          reject(new Error(`Companion socket failed to connect: ${err.message}`));
+        }
+      });
+
+      ws.on('message', (data: WebSocket.RawData) => {
+        this.handleMessage(data.toString());
+      });
+
+      ws.on('close', (code: number) => {
+        debug('companion socket closed (code=%d)', code);
+        this.ws = null;
+      });
+    });
+  }
+
+  /** Registers a callback that fires each time the device completes an orientation change. */
+  onOrientationFinish(handler: OrientationFinishHandler): void {
+    this.orientationHandler = handler;
+  }
+
+  /** Closes the WebSocket cleanly, preventing any further event delivery. */
+  disconnect(): Promise<void> {
+    const ws = this.ws;
+    if (!ws) return Promise.resolve();
+    this.ws = null;
+    return new Promise<void>((resolve) => {
+      ws.once('close', () => resolve());
+      ws.close(WS_CLOSE_NORMAL);
+    });
+  }
+
+  /** Parses an incoming JSON event and dispatches it to the appropriate handler. */
+  private handleMessage(raw: string): void {
+    let msg: { type?: string; value?: { orientation?: string } };
+    try {
+      msg = JSON.parse(raw) as typeof msg;
+    } catch {
+      return;
+    }
+
+    debug('companion event %s', msg.type);
+
+    if (msg.type === 'device.orientation.finish' && msg.value?.orientation) {
+      const orientation = msg.value.orientation.toUpperCase() as 'PORTRAIT' | 'LANDSCAPE';
+      this.orientationHandler?.(orientation);
+    }
+  }
+}

--- a/packages/driver-saucelabs/src/device-control-socket.test.ts
+++ b/packages/driver-saucelabs/src/device-control-socket.test.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '@playwright/test';
+import { DeviceControlSocket } from './device-control-socket.js';
+
+// Inject a pre-connected fake ws so tests don't need a real server.
+function createConnectedSocket() {
+  const sent: string[] = [];
+  const socket = new DeviceControlSocket('wss://fake', 'user', 'key');
+  (socket as any).ws = {
+    readyState: 1, // WebSocket.OPEN
+    send: (msg: string) => sent.push(msg),
+  };
+  return { socket, sent };
+}
+
+// ─── sendTouch ───────────────────────────────────────────────────────────────
+
+test.describe('DeviceControlSocket.sendTouch()', () => {
+  test('produces correct mt/d message for a single portrait touch', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendTouch('d', [{ x: 540, y: 960, index: 0 }], 1080, 1920, 0);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toBe('mt/d 1080 1920 0 1 0 540 960');
+  });
+
+  test('produces correct mt/u message for touch up', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendTouch('u', [{ x: 540, y: 960, index: 0 }], 1080, 1920, 0);
+
+    expect(sent[0]).toBe('mt/u 1080 1920 0 1 0 540 960');
+  });
+
+  test('produces correct mt/m message for touch move', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendTouch('m', [{ x: 300, y: 500, index: 0 }], 1080, 1920, 0);
+
+    expect(sent[0]).toBe('mt/m 1080 1920 0 1 0 300 500');
+  });
+
+  test('sets orientation flag to 1 for landscape', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendTouch('d', [{ x: 960, y: 540, index: 0 }], 1920, 1080, 1);
+
+    expect(sent[0]).toBe('mt/d 1920 1080 1 1 0 960 540');
+  });
+
+  test('rounds fractional coordinates', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendTouch('d', [{ x: 540.6, y: 960.4, index: 0 }], 1080, 1920, 0);
+
+    expect(sent[0]).toBe('mt/d 1080 1920 0 1 0 541 960');
+  });
+
+  test('encodes two touch points for multi-touch', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendTouch(
+      'd',
+      [{ x: 150, y: 300, index: 0 }, { x: 210, y: 340, index: 1 }],
+      360,
+      640,
+      0,
+    );
+
+    expect(sent[0]).toBe('mt/d 360 640 0 2 0 150 300 1 210 340');
+  });
+});
+
+// ─── sendKey ─────────────────────────────────────────────────────────────────
+
+test.describe('DeviceControlSocket.sendKey()', () => {
+  test('produces tt/a for letter a', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendKey('a');
+    expect(sent[0]).toBe('tt/a');
+  });
+
+  test('produces tt/Enter for Enter key', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendKey('Enter');
+    expect(sent[0]).toBe('tt/Enter');
+  });
+
+  test('produces tt/Backspace for Backspace key', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendKey('Backspace');
+    expect(sent[0]).toBe('tt/Backspace');
+  });
+
+  test('produces tt/Sauce_Home_Key for home navigation', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendKey('Sauce_Home_Key');
+    expect(sent[0]).toBe('tt/Sauce_Home_Key');
+  });
+
+  test('produces tt/Sauce_Back_Key for back navigation', () => {
+    const { socket, sent } = createConnectedSocket();
+    socket.sendKey('Sauce_Back_Key');
+    expect(sent[0]).toBe('tt/Sauce_Back_Key');
+  });
+});
+
+// ─── Frame capture ───────────────────────────────────────────────────────────
+
+test.describe('frame capture', () => {
+  test('stopFrameCapture returns empty array when capture was never started', () => {
+    const { socket } = createConnectedSocket();
+    const frames = socket.stopFrameCapture();
+    expect(frames).toEqual([]);
+  });
+
+  test('startFrameCapture then stopFrameCapture returns accumulated frames', () => {
+    const { socket } = createConnectedSocket();
+
+    socket.startFrameCapture();
+    // Simulate binary frames arriving by pushing directly to the internal array
+    (socket as any).capturedFrames.push(Buffer.from('frame1'));
+    (socket as any).capturedFrames.push(Buffer.from('frame2'));
+
+    const frames = socket.stopFrameCapture();
+    expect(frames).toHaveLength(2);
+    expect(frames[0].toString()).toBe('frame1');
+    expect(frames[1].toString()).toBe('frame2');
+  });
+
+  test('stopFrameCapture clears the internal buffer so second call returns empty', () => {
+    const { socket } = createConnectedSocket();
+
+    socket.startFrameCapture();
+    (socket as any).capturedFrames.push(Buffer.from('frame1'));
+    socket.stopFrameCapture();
+
+    const second = socket.stopFrameCapture();
+    expect(second).toEqual([]);
+  });
+
+  test('frames captured after startFrameCapture are not included before it', () => {
+    const { socket } = createConnectedSocket();
+
+    // Push a frame before starting capture — should be discarded
+    (socket as any).capturedFrames.push(Buffer.from('pre-capture'));
+    socket.startFrameCapture(); // resets the buffer
+
+    (socket as any).capturedFrames.push(Buffer.from('post-capture'));
+    const frames = socket.stopFrameCapture();
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].toString()).toBe('post-capture');
+  });
+});
+
+// ─── Error when not connected ─────────────────────────────────────────────────
+
+test('sendKey throws when socket is not connected', () => {
+  const socket = new DeviceControlSocket('wss://fake', 'user', 'key');
+  // ws is null — never connected
+  expect(() => socket.sendKey('a')).toThrow('not connected');
+});
+
+test('sendTouch throws when socket is not connected', () => {
+  const socket = new DeviceControlSocket('wss://fake', 'user', 'key');
+  expect(() => socket.sendTouch('d', [{ x: 0, y: 0, index: 0 }], 1080, 1920, 0)).toThrow('not connected');
+});

--- a/packages/driver-saucelabs/src/device-control-socket.ts
+++ b/packages/driver-saucelabs/src/device-control-socket.ts
@@ -1,0 +1,174 @@
+import createDebug from 'debug';
+import WebSocket from 'ws';
+
+const debug = createDebug('mw:driver-saucelabs:io');
+
+const WS_CLOSE_NORMAL = 1000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_MS = 1_000;
+
+export interface TouchPoint {
+  x: number;
+  y: number;
+  index: number;
+}
+
+/** WebSocket connection to the Sauce Labs device I/O channel for sending touch and keyboard events and receiving MJPEG screen frames. */
+export class DeviceControlSocket {
+  private ws: WebSocket | null = null;
+  private readonly authHeader: string;
+  private capturing = false;
+  private capturedFrames: { frame: Buffer; ts: number }[] = [];
+  private captureEndTs = 0;
+  private reconnectAttempts = 0;
+  private closed = false;
+
+  constructor(
+    private readonly url: string,
+    username: string,
+    accessKey: string,
+  ) {
+    this.authHeader = `Basic ${Buffer.from(`${username}:${accessKey}`).toString('base64')}`;
+  }
+
+  /** Opens the WebSocket and resets reconnect state; auto-reconnects on unexpected disconnects. */
+  async connect(): Promise<void> {
+    this.closed = false;
+    this.reconnectAttempts = 0;
+    await this.openSocket();
+  }
+
+  /** Creates the underlying WebSocket, wires up event handlers, and resolves once the connection is open. */
+  private openSocket(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(this.url, {
+        headers: { Authorization: this.authHeader },
+      });
+
+      ws.on('open', () => {
+        debug('device control socket connected');
+        this.ws = ws;
+        this.reconnectAttempts = 0;
+        resolve();
+      });
+
+      ws.on('error', (err) => {
+        debug('device control socket error: %s', err.message);
+        if (!this.ws) {
+          reject(new Error(`Device control socket failed to connect: ${err.message}`));
+        }
+      });
+
+      ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+        if (isBinary) {
+          const frame = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
+          if (this.capturing) {
+            this.capturedFrames.push({ frame, ts: Date.now() });
+          }
+          // Always ack to keep the frame stream flowing
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send('n/');
+          }
+        }
+      });
+
+      ws.on('close', (code: number) => {
+        debug('device control socket closed (code=%d)', code);
+        this.ws = null;
+        if (!this.closed && code !== WS_CLOSE_NORMAL) {
+          this.scheduleReconnect();
+        }
+      });
+    });
+  }
+
+  /** Schedules a reconnect attempt with exponential backoff, up to MAX_RECONNECT_ATTEMPTS tries. */
+  private scheduleReconnect(): void {
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      debug('device control socket: max reconnect attempts reached');
+      return;
+    }
+    const delay = RECONNECT_BASE_MS * Math.pow(2, this.reconnectAttempts);
+    this.reconnectAttempts++;
+    debug('device control socket: reconnecting in %dms (attempt %d)', delay, this.reconnectAttempts);
+    setTimeout(() => {
+      if (!this.closed) {
+        this.openSocket().catch((err) => {
+          debug('reconnect failed: %s', err.message);
+          this.scheduleReconnect();
+        });
+      }
+    }, delay);
+  }
+
+  /** Closes the WebSocket with a normal close code so reconnect logic does not trigger. */
+  disconnect(): Promise<void> {
+    this.closed = true;
+    const ws = this.ws;
+    if (!ws) return Promise.resolve();
+    this.ws = null;
+    return new Promise<void>((resolve) => {
+      ws.once('close', () => resolve());
+      ws.close(WS_CLOSE_NORMAL);
+    });
+  }
+
+  // ─── Touch ────────────────────────────────────────────────────────────────
+
+  /** Sends a multi-touch action (down/move/up) with one or more contact points to the device. */
+  sendTouch(
+    action: 'd' | 'm' | 'u',
+    points: TouchPoint[],
+    canvasW: number,
+    canvasH: number,
+    orientation: 0 | 1,
+  ): void {
+    const touchCount = points.length;
+    const parts: string[] = [`mt/${action}`, String(canvasW), String(canvasH), String(orientation), String(touchCount)];
+    for (const p of points) {
+      parts.push(String(p.index), String(Math.round(p.x)), String(Math.round(p.y)));
+    }
+    this.send(parts.join(' '));
+  }
+
+  /** Sends a keyboard event for the given key name through the device I/O channel. */
+  sendKey(key: string): void {
+    this.send(`tt/${key}`);
+  }
+
+  // ─── Recording ────────────────────────────────────────────────────────────
+
+  /** Starts buffering incoming MJPEG frames for later video encoding. */
+  startFrameCapture(): void {
+    this.capturedFrames = [];
+    this.captureEndTs = 0;
+    this.capturing = true;
+    debug('frame capture started');
+  }
+
+  /** Stops buffering frames and returns the captured set, clearing the internal buffer. */
+  stopFrameCapture(): { frame: Buffer; ts: number }[] {
+    this.capturing = false;
+    this.captureEndTs = Date.now();
+    const frames = this.capturedFrames;
+    this.capturedFrames = [];
+    debug('frame capture stopped, %d frames captured', frames.length);
+    return frames;
+  }
+
+  /** Returns the wall-clock timestamp (ms) recorded when frame capture was stopped, used to compute video duration. */
+  getCaptureEndTs(): number {
+    return this.captureEndTs;
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  private send(msg: string): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error('Device control socket is not connected');
+    }
+    debug('send %s', msg);
+    ws.send(msg);
+  }
+}

--- a/packages/driver-saucelabs/src/driver.test.ts
+++ b/packages/driver-saucelabs/src/driver.test.ts
@@ -355,11 +355,18 @@ test.describe('SauceLabsDriver.longPress()', () => {
 });
 
 test.describe('SauceLabsDriver.clearText()', () => {
-  test('sends select-all (a) then Backspace', async () => {
-    const { driver, ioSocket } = createDriverWithSession();
+  test('sends cmd+a then Backspace on iOS', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'ios' });
     await driver.clearText();
 
-    expect(ioSocket.keyCalls).toEqual(['a', 'Backspace']);
+    expect(ioSocket.keyCalls).toEqual(['cmd+a', 'Backspace']);
+  });
+
+  test('sends ctrl+a then Backspace on Android', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'android' });
+    await driver.clearText();
+
+    expect(ioSocket.keyCalls).toEqual(['ctrl+a', 'Backspace']);
   });
 });
 
@@ -456,10 +463,8 @@ test.describe('SauceLabsDriver.pressButton()', () => {
     expect(call?.args[1]).toContain('keyevent 25');
   });
 
-  test('VOLUME_UP on iOS tries socket then falls back to WDA pressButton', async () => {
-    const { driver, wda, ioSocket } = createDriverWithSession({ platform: 'ios' });
-    // Make the socket throw to trigger the WDA fallback path
-    ioSocket.sendKey = () => { throw new Error('socket error'); };
+  test('VOLUME_UP on iOS goes directly to WDA pressButton', async () => {
+    const { driver, wda } = createDriverWithSession({ platform: 'ios' });
     await driver.pressButton('VOLUME_UP');
 
     expect(wda!.calls.find((c) => c.method === 'pressButton')?.args[0]).toBe('volumeUp');

--- a/packages/driver-saucelabs/src/driver.test.ts
+++ b/packages/driver-saucelabs/src/driver.test.ts
@@ -1,0 +1,857 @@
+import { expect, test } from '@playwright/test';
+import type { AppInfo, ViewNode } from '@mobilewright/protocol';
+import { SauceLabsDriver } from './driver.js';
+import type { TouchPoint } from './device-control-socket.js';
+
+// ─── Fake helpers ────────────────────────────────────────────────────────────
+
+interface TouchCall {
+  action: 'd' | 'm' | 'u';
+  points: TouchPoint[];
+  cw: number;
+  ch: number;
+  orientation: 0 | 1;
+}
+
+function createFakeIoSocket() {
+  const touchCalls: TouchCall[] = [];
+  const keyCalls: string[] = [];
+  let capturing = false;
+  let frames: Buffer[] = [];
+
+  return {
+    touchCalls,
+    keyCalls,
+    setFramesToReturn(f: Buffer[]) { frames = f; },
+    sendTouch(action: 'd' | 'm' | 'u', points: TouchPoint[], cw: number, ch: number, orientation: 0 | 1) {
+      touchCalls.push({ action, points, cw, ch, orientation });
+    },
+    sendKey(key: string) { keyCalls.push(key); },
+    startFrameCapture() { capturing = true; },
+    stopFrameCapture() { const f = frames; capturing = false; return f; },
+    connect: async () => {},
+    disconnect: async () => {},
+    get isCapturing() { return capturing; },
+  };
+}
+
+interface RestCall { method: string; args: unknown[] }
+
+function createFakeRest(responses: Record<string, unknown> = {}) {
+  const calls: RestCall[] = [];
+  const rest = new Proxy({} as Record<string, (...args: unknown[]) => Promise<unknown>>, {
+    get(_, method: string) {
+      return async (...args: unknown[]) => {
+        calls.push({ method, args });
+        const val = responses[method];
+        if (val instanceof Error) throw val;
+        return val;
+      };
+    },
+  });
+  return { rest, calls };
+}
+
+interface WdaCall { method: string; args: unknown[] }
+
+function createFakeWda(responses: Record<string, unknown> = {}) {
+  const calls: WdaCall[] = [];
+  return {
+    calls,
+    close: async () => {
+    },
+    getSource: async (): Promise<ViewNode[]> => {
+      calls.push({ method: 'getSource', args: [] });
+      return (responses['getSource'] as ViewNode[]) ?? [];
+    },
+    getActiveAppInfo: async (): Promise<AppInfo> => {
+      calls.push({ method: 'getActiveAppInfo', args: [] });
+      return (responses['getActiveAppInfo'] as AppInfo) ?? { bundleId: '' };
+    },
+    listApps: async (): Promise<AppInfo[]> => {
+      calls.push({ method: 'listApps', args: [] });
+      return (responses['listApps'] as AppInfo[]) ?? [];
+    },
+    terminateApp: async (bundleId: string) => {
+      calls.push({ method: 'terminateApp', args: [bundleId] });
+    },
+    pressButton: async (name: string) => {
+      calls.push({ method: 'pressButton', args: [name] });
+    },
+  };
+}
+
+type Platform = 'ios' | 'android';
+
+interface SessionOptions {
+  platform?: Platform;
+  resolutionWidth?: number;
+  resolutionHeight?: number;
+  pixelsPerPoint?: number;
+  currentOrientation?: 'PORTRAIT' | 'LANDSCAPE';
+  restResponses?: Record<string, unknown>;
+  wdaResponses?: Record<string, unknown>;
+}
+
+/**
+ * Creates a SauceLabsDriver with a pre-injected fake session — no real
+ * WebSocket or HTTP server needed. Mirrors the pattern from driver-mobilecli.
+ */
+function createDriverWithSession(opts: SessionOptions = {}) {
+  const platform: Platform = opts.platform ?? 'ios';
+  const driver = new SauceLabsDriver({ username: 'alice', accessKey: 'secret' });
+
+  const ioSocket = createFakeIoSocket();
+  const wda = platform === 'ios' ? createFakeWda(opts.wdaResponses ?? {}) : null;
+
+  (driver as any).session = {
+    sauceSessionId: 'sess-123',
+    platform,
+    deviceId: 'iPhone_15_real',
+    resolutionWidth: opts.resolutionWidth ?? 1170,
+    resolutionHeight: opts.resolutionHeight ?? 2532,
+    pixelsPerPoint: opts.pixelsPerPoint ?? 3,
+    currentOrientation: opts.currentOrientation ?? 'PORTRAIT',
+    ioSocket,
+    companionSocket: { onOrientationFinish: () => {}, disconnect: async () => {} },
+    wdaClient: wda,
+  };
+
+  const { rest, calls: restCalls } = createFakeRest(opts.restResponses ?? {});
+  (driver as any).makeRest = () => rest;
+
+  return { driver, ioSocket, wda, restCalls };
+}
+
+// ─── Constructor ─────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver constructor', () => {
+  test('reads credentials from SAUCE_USERNAME and SAUCE_ACCESS_KEY env vars', () => {
+    const orig = { u: process.env['SAUCE_USERNAME'], k: process.env['SAUCE_ACCESS_KEY'] };
+    process.env['SAUCE_USERNAME'] = 'env-user';
+    process.env['SAUCE_ACCESS_KEY'] = 'env-key';
+    try {
+      expect(() => new SauceLabsDriver()).not.toThrow();
+    } finally {
+      if (orig.u === undefined) delete process.env['SAUCE_USERNAME']; else process.env['SAUCE_USERNAME'] = orig.u;
+      if (orig.k === undefined) delete process.env['SAUCE_ACCESS_KEY']; else process.env['SAUCE_ACCESS_KEY'] = orig.k;
+    }
+  });
+
+  test('explicit options take precedence over env vars', () => {
+    const orig = { u: process.env['SAUCE_USERNAME'], k: process.env['SAUCE_ACCESS_KEY'] };
+    process.env['SAUCE_USERNAME'] = 'env-user';
+    process.env['SAUCE_ACCESS_KEY'] = 'env-key';
+    try {
+      const driver = new SauceLabsDriver({ username: 'opt-user', accessKey: 'opt-key' });
+      expect((driver as any).username).toBe('opt-user');
+    } finally {
+      if (orig.u === undefined) delete process.env['SAUCE_USERNAME']; else process.env['SAUCE_USERNAME'] = orig.u;
+      if (orig.k === undefined) delete process.env['SAUCE_ACCESS_KEY']; else process.env['SAUCE_ACCESS_KEY'] = orig.k;
+    }
+  });
+
+  test('throws with helpful message when username is missing', () => {
+    const orig = process.env['SAUCE_USERNAME'];
+    delete process.env['SAUCE_USERNAME'];
+    try {
+      expect(() => new SauceLabsDriver({ accessKey: 'k' })).toThrow('SAUCE_USERNAME');
+    } finally {
+      if (orig !== undefined) process.env['SAUCE_USERNAME'] = orig;
+    }
+  });
+
+  test('throws with helpful message when accessKey is missing', () => {
+    const orig = process.env['SAUCE_ACCESS_KEY'];
+    delete process.env['SAUCE_ACCESS_KEY'];
+    try {
+      expect(() => new SauceLabsDriver({ username: 'u' })).toThrow('SAUCE_ACCESS_KEY');
+    } finally {
+      if (orig !== undefined) process.env['SAUCE_ACCESS_KEY'] = orig;
+    }
+  });
+});
+
+// ─── Session guard ────────────────────────────────────────────────────────────
+
+test('screenshot() throws "No active session" when connect() was never called', async () => {
+  const driver = new SauceLabsDriver({ username: 'u', accessKey: 'k' });
+  await expect(driver.screenshot()).rejects.toThrow('No active session');
+});
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.getScreenSize()', () => {
+  test('divides resolution by pixelsPerPoint (scale)', async () => {
+    const { driver } = createDriverWithSession({ resolutionWidth: 1170, resolutionHeight: 2532, pixelsPerPoint: 3 });
+    const size = await driver.getScreenSize();
+    expect(size).toEqual({ width: 390, height: 844, scale: 3 });
+  });
+
+  test('swaps width and height in landscape orientation', async () => {
+    const { driver } = createDriverWithSession({
+      resolutionWidth: 1170,
+      resolutionHeight: 2532,
+      pixelsPerPoint: 3,
+      currentOrientation: 'LANDSCAPE',
+    });
+    const size = await driver.getScreenSize();
+    expect(size).toEqual({ width: 844, height: 390, scale: 3 });
+  });
+
+  test('uses scale 1 when pixelsPerPoint is 0', async () => {
+    const { driver } = createDriverWithSession({ resolutionWidth: 1080, resolutionHeight: 1920, pixelsPerPoint: 0 });
+    const size = await driver.getScreenSize();
+    expect(size.scale).toBe(1);
+    expect(size.width).toBe(1080);
+  });
+});
+
+test.describe('SauceLabsDriver.getOrientation()', () => {
+  test('returns portrait when session orientation is PORTRAIT', async () => {
+    const { driver } = createDriverWithSession({ currentOrientation: 'PORTRAIT' });
+    expect(await driver.getOrientation()).toBe('portrait');
+  });
+
+  test('returns landscape when session orientation is LANDSCAPE', async () => {
+    const { driver } = createDriverWithSession({ currentOrientation: 'LANDSCAPE' });
+    expect(await driver.getOrientation()).toBe('landscape');
+  });
+});
+
+test.describe('SauceLabsDriver.setOrientation()', () => {
+  test('calls applySettings with LANDSCAPE for landscape', async () => {
+    const { driver, restCalls } = createDriverWithSession();
+    await driver.setOrientation('landscape');
+
+    const call = restCalls.find((c) => c.method === 'applySettings');
+    expect(call?.args[1]).toMatchObject({ orientation: 'LANDSCAPE' });
+  });
+
+  test('calls applySettings with PORTRAIT for portrait', async () => {
+    const { driver, restCalls } = createDriverWithSession({ currentOrientation: 'LANDSCAPE' });
+    await driver.setOrientation('portrait');
+
+    const call = restCalls.find((c) => c.method === 'applySettings');
+    expect(call?.args[1]).toMatchObject({ orientation: 'PORTRAIT' });
+  });
+});
+
+test.describe('SauceLabsDriver.screenshot()', () => {
+  test('returns the Buffer from takeScreenshot', async () => {
+    const buf = Buffer.from([137, 80, 78, 71]);
+    const { driver } = createDriverWithSession({ restResponses: { takeScreenshot: buf } });
+    const result = await driver.screenshot();
+    expect(result).toBe(buf);
+  });
+});
+
+// ─── Input ───────────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.tap()', () => {
+  test('sends touch down then touch up at same coordinates', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'android' });
+    await driver.tap(540, 960);
+
+    expect(ioSocket.touchCalls).toHaveLength(2);
+    expect(ioSocket.touchCalls[0].action).toBe('d');
+    expect(ioSocket.touchCalls[1].action).toBe('u');
+    expect(ioSocket.touchCalls[0].points[0]).toMatchObject({ x: 540, y: 960, index: 0 });
+    expect(ioSocket.touchCalls[1].points[0]).toMatchObject({ x: 540, y: 960, index: 0 });
+  });
+
+  test('uses portrait canvas dimensions in portrait orientation', async () => {
+    const { driver, ioSocket } = createDriverWithSession({
+      resolutionWidth: 1080,
+      resolutionHeight: 1920,
+      pixelsPerPoint: 1,
+      currentOrientation: 'PORTRAIT',
+    });
+    await driver.tap(0, 0);
+
+    expect(ioSocket.touchCalls[0].cw).toBe(1080);
+    expect(ioSocket.touchCalls[0].ch).toBe(1920);
+    expect(ioSocket.touchCalls[0].orientation).toBe(0);
+  });
+
+  test('swaps canvas dimensions and sets orientation flag in landscape', async () => {
+    const { driver, ioSocket } = createDriverWithSession({
+      resolutionWidth: 1080,
+      resolutionHeight: 1920,
+      pixelsPerPoint: 1,
+      currentOrientation: 'LANDSCAPE',
+    });
+    await driver.tap(0, 0);
+
+    expect(ioSocket.touchCalls[0].cw).toBe(1920);
+    expect(ioSocket.touchCalls[0].ch).toBe(1080);
+    expect(ioSocket.touchCalls[0].orientation).toBe(1);
+  });
+});
+
+test.describe('SauceLabsDriver.doubleTap()', () => {
+  test('sends two complete tap sequences', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.doubleTap(200, 300);
+
+    const actions = ioSocket.touchCalls.map((c) => c.action);
+    expect(actions).toEqual(['d', 'u', 'd', 'u']);
+  });
+
+  test('all touches are at the given coordinates', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.doubleTap(200, 300);
+
+    for (const call of ioSocket.touchCalls) {
+      expect(call.points[0]).toMatchObject({ x: 200, y: 300 });
+    }
+  });
+});
+
+test.describe('SauceLabsDriver.longPress()', () => {
+  test('sends touch down followed by touch up', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.longPress(100, 200, 10); // short duration for test speed
+
+    const actions = ioSocket.touchCalls.map((c) => c.action);
+    expect(actions[0]).toBe('d');
+    expect(actions[actions.length - 1]).toBe('u');
+  });
+});
+
+test.describe('SauceLabsDriver.clearText()', () => {
+  test('sends select-all (a) then Backspace', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.clearText();
+
+    expect(ioSocket.keyCalls).toEqual(['a', 'Backspace']);
+  });
+});
+
+test.describe('SauceLabsDriver.typeText()', () => {
+  test('sends each ASCII character as a tt/ key event', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.typeText('hi');
+
+    expect(ioSocket.keyCalls).toEqual(['h', 'i']);
+  });
+
+  test('sends Space key for space character', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.typeText(' ');
+
+    expect(ioSocket.keyCalls).toEqual(['Space']);
+  });
+
+  test('calls executeShellCommand for non-ASCII text on Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.typeText('こんにちは');
+
+    const shellCall = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect(shellCall).toBeDefined();
+    expect((shellCall!.args[1] as string)).toContain('input text');
+  });
+
+  test('does not call executeShellCommand for ASCII text on Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.typeText('hello');
+
+    const shellCall = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect(shellCall).toBeUndefined();
+  });
+});
+
+test.describe('SauceLabsDriver.pressKeys()', () => {
+  test('sends each key as a tt/ event in order', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.pressKeys(['Enter', 'Tab']);
+
+    expect(ioSocket.keyCalls).toEqual(['Enter', 'Tab']);
+  });
+});
+
+// ─── pressButton ─────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.pressButton()', () => {
+  test('HOME sends tt/Sauce_Home_Key on iOS', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'ios' });
+    await driver.pressButton('HOME');
+    expect(ioSocket.keyCalls).toContain('Sauce_Home_Key');
+  });
+
+  test('HOME sends tt/Sauce_Home_Key on Android', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'android' });
+    await driver.pressButton('HOME');
+    expect(ioSocket.keyCalls).toContain('Sauce_Home_Key');
+  });
+
+  test('BACK sends tt/Sauce_Back_Key', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'android' });
+    await driver.pressButton('BACK');
+    expect(ioSocket.keyCalls).toContain('Sauce_Back_Key');
+  });
+
+  test('APP_SWITCH sends tt/Sauce_Menu_Key', async () => {
+    const { driver, ioSocket } = createDriverWithSession({ platform: 'android' });
+    await driver.pressButton('APP_SWITCH');
+    expect(ioSocket.keyCalls).toContain('Sauce_Menu_Key');
+  });
+
+  test('VOLUME_UP on Android calls executeShellCommand with keyevent 24', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.pressButton('VOLUME_UP');
+
+    const call = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect(call?.args[1]).toContain('keyevent 24');
+  });
+
+  test('POWER on Android calls executeShellCommand with keyevent 26', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.pressButton('POWER');
+
+    const call = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect(call?.args[1]).toContain('keyevent 26');
+  });
+
+  test('VOLUME_DOWN on Android calls executeShellCommand with keyevent 25', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.pressButton('VOLUME_DOWN');
+
+    const call = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect(call?.args[1]).toContain('keyevent 25');
+  });
+
+  test('VOLUME_UP on iOS tries socket then falls back to WDA pressButton', async () => {
+    const { driver, wda, ioSocket } = createDriverWithSession({ platform: 'ios' });
+    // Make the socket throw to trigger the WDA fallback path
+    ioSocket.sendKey = () => { throw new Error('socket error'); };
+    await driver.pressButton('VOLUME_UP');
+
+    expect(wda!.calls.find((c) => c.method === 'pressButton')?.args[0]).toBe('volumeUp');
+  });
+});
+
+// ─── Apps ────────────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.launchApp()', () => {
+  test('sends bundleId for iOS', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'ios' });
+    await driver.launchApp('com.example.App');
+
+    const call = restCalls.find((c) => c.method === 'launchApp');
+    expect(call?.args[1]).toMatchObject({ bundleId: 'com.example.App' });
+    expect((call?.args[1] as Record<string, unknown>)['packageName']).toBeUndefined();
+  });
+
+  test('sends packageName for Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.launchApp('com.example.app');
+
+    const call = restCalls.find((c) => c.method === 'launchApp');
+    expect(call?.args[1]).toMatchObject({ packageName: 'com.example.app' });
+  });
+
+  test('includes activityName for Android when activity option is provided', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.launchApp('com.example.app', { activity: '.MainActivity' });
+
+    const call = restCalls.find((c) => c.method === 'launchApp');
+    expect(call?.args[1]).toMatchObject({ activityName: '.MainActivity' });
+  });
+
+  test('omits activityName when no activity option is provided', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.launchApp('com.example.app');
+
+    const call = restCalls.find((c) => c.method === 'launchApp');
+    expect((call?.args[1] as Record<string, unknown>)['activityName']).toBeUndefined();
+  });
+});
+
+test.describe('SauceLabsDriver.terminateApp()', () => {
+  test('calls executeShellCommand with am force-stop on Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.terminateApp('com.example.app');
+
+    const call = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect(call?.args[1]).toBe('am force-stop com.example.app');
+  });
+
+  test('calls WDA terminateApp on iOS', async () => {
+    const { driver, wda } = createDriverWithSession({ platform: 'ios' });
+    await driver.terminateApp('com.example.App');
+
+    expect(wda!.calls.find((c) => c.method === 'terminateApp')?.args[0]).toBe('com.example.App');
+  });
+});
+
+test.describe('SauceLabsDriver.installApp()', () => {
+  test('uploads file to storage then calls installApp REST', async () => {
+    const { driver, restCalls } = createDriverWithSession({
+      restResponses: { uploadToStorage: 'storage:uuid-abc' },
+    });
+    await driver.installApp('/path/to/app.apk');
+
+    const uploadCall = restCalls.find((c) => c.method === 'uploadToStorage');
+    expect(uploadCall?.args[0]).toBe('/path/to/app.apk');
+
+    const installCall = restCalls.find((c) => c.method === 'installApp');
+    expect(installCall?.args[1]).toBe('storage:uuid-abc');
+  });
+});
+
+test.describe('SauceLabsDriver.uninstallApp()', () => {
+  test('sends bundleId for iOS', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'ios' });
+    await driver.uninstallApp('com.example.App');
+
+    const call = restCalls.find((c) => c.method === 'uninstallApp');
+    expect(call?.args[1]).toMatchObject({ bundleId: 'com.example.App' });
+  });
+
+  test('sends packageName for Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.uninstallApp('com.example.app');
+
+    const call = restCalls.find((c) => c.method === 'uninstallApp');
+    expect(call?.args[1]).toMatchObject({ packageName: 'com.example.app' });
+  });
+});
+
+test.describe('SauceLabsDriver.listApps()', () => {
+  test('parses pm list packages output on Android', async () => {
+    const { driver } = createDriverWithSession({
+      platform: 'android',
+      restResponses: { executeShellCommand: 'package:com.example.one\npackage:com.example.two\n' },
+    });
+    const apps = await driver.listApps();
+
+    expect(apps).toEqual([
+      { bundleId: 'com.example.one' },
+      { bundleId: 'com.example.two' },
+    ]);
+  });
+
+  test('ignores non-package lines in pm output', async () => {
+    const { driver } = createDriverWithSession({
+      platform: 'android',
+      restResponses: { executeShellCommand: 'WARNING: linker\npackage:com.example.app\n' },
+    });
+    const apps = await driver.listApps();
+    expect(apps).toHaveLength(1);
+    expect(apps[0].bundleId).toBe('com.example.app');
+  });
+
+  test('delegates to WDA on iOS', async () => {
+    const wdaApps = [{ bundleId: 'com.apple.Music' }];
+    const { driver, wda } = createDriverWithSession({
+      platform: 'ios',
+      wdaResponses: { listApps: wdaApps },
+    });
+    const apps = await driver.listApps();
+
+    expect(wda!.calls.find((c) => c.method === 'listApps')).toBeDefined();
+    expect(apps).toEqual(wdaApps);
+  });
+});
+
+test.describe('SauceLabsDriver.getForegroundApp()', () => {
+  test('parses mResumedActivity from dumpsys output on Android', async () => {
+    const { driver } = createDriverWithSession({
+      platform: 'android',
+      restResponses: {
+        executeShellCommand: '  mResumedActivity: ActivityRecord{abc12 u0 com.example.app/.MainActivity t42}\n',
+      },
+    });
+    const app = await driver.getForegroundApp();
+    expect(app.bundleId).toBe('com.example.app');
+  });
+
+  test('returns empty bundleId when mResumedActivity line is absent', async () => {
+    const { driver } = createDriverWithSession({
+      platform: 'android',
+      restResponses: { executeShellCommand: 'no matching line here\n' },
+    });
+    const app = await driver.getForegroundApp();
+    expect(app.bundleId).toBe('');
+  });
+
+  test('delegates to WDA on iOS', async () => {
+    const { driver, wda } = createDriverWithSession({
+      platform: 'ios',
+      wdaResponses: { getActiveAppInfo: { bundleId: 'com.apple.Maps', name: 'Maps' } },
+    });
+    const app = await driver.getForegroundApp();
+
+    expect(wda!.calls.find((c) => c.method === 'getActiveAppInfo')).toBeDefined();
+    expect(app.bundleId).toBe('com.apple.Maps');
+  });
+});
+
+test.describe('SauceLabsDriver.openUrl()', () => {
+  test('calls REST openUrl with the given URL', async () => {
+    const { driver, restCalls } = createDriverWithSession();
+    await driver.openUrl('https://example.com');
+
+    const call = restCalls.find((c) => c.method === 'openUrl');
+    expect(call?.args[1]).toBe('https://example.com');
+  });
+});
+
+// ─── Device settings ─────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.applyDeviceSettings()', () => {
+  test('calls applySettings with animations=false for { animations: off } on Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.applyDeviceSettings({ animations: 'off' });
+
+    const call = restCalls.find((c) => c.method === 'applySettings');
+    expect(call?.args[1]).toMatchObject({ animations: false });
+  });
+
+  test('calls applySettings with animations=true for { animations: on } on Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'android' });
+    await driver.applyDeviceSettings({ animations: 'on' });
+
+    const call = restCalls.find((c) => c.method === 'applySettings');
+    expect(call?.args[1]).toMatchObject({ animations: true });
+  });
+
+  test('does not call applySettings for animations on iOS', async () => {
+    const { driver, restCalls } = createDriverWithSession({ platform: 'ios' });
+    await driver.applyDeviceSettings({ animations: 'off' });
+
+    const call = restCalls.find((c) => c.method === 'applySettings');
+    expect(call).toBeUndefined();
+  });
+});
+
+// ─── Device list ─────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.listDevices()', () => {
+  const descriptors = [
+    { id: 'iPhone_15_real', name: 'iPhone 15', os: 'IOS', osVersion: '17.0' },
+    { id: 'Samsung_S24_real', name: 'Samsung S24', os: 'ANDROID', osVersion: '14' },
+  ];
+  const statusResp = {
+    devices: [
+      { descriptor: 'iPhone_15_real', isPrivateDevice: false, state: 'AVAILABLE' },
+      { descriptor: 'Samsung_S24_real', isPrivateDevice: false, state: 'IN_USE' },
+    ],
+  };
+
+  test('returns merged descriptor + status list', async () => {
+    const { driver } = createDriverWithSession({
+      restResponses: { listDevices: descriptors, listDeviceStatus: statusResp },
+    });
+    const devices = await driver.listDevices();
+
+    expect(devices).toHaveLength(2);
+    expect(devices[0].id).toBe('iPhone_15_real');
+    expect(devices[0].platform).toBe('ios');
+    expect(devices[0].state).toBe('online');
+    expect(devices[1].state).toBe('offline');
+  });
+
+  test('maps IN_USE device state to offline', async () => {
+    const { driver } = createDriverWithSession({
+      restResponses: { listDevices: descriptors, listDeviceStatus: statusResp },
+    });
+    const devices = await driver.listDevices();
+    expect(devices.find((d) => d.id === 'Samsung_S24_real')?.state).toBe('offline');
+  });
+
+  test('filters by platform when opts.platform is set', async () => {
+    const { driver } = createDriverWithSession({
+      restResponses: { listDevices: descriptors, listDeviceStatus: statusResp },
+    });
+    const devices = await driver.listDevices({ platform: 'ios' });
+
+    expect(devices.every((d) => d.platform === 'ios')).toBe(true);
+    expect(devices).toHaveLength(1);
+  });
+
+  test('filters by state when opts.state is set', async () => {
+    const { driver } = createDriverWithSession({
+      restResponses: { listDevices: descriptors, listDeviceStatus: statusResp },
+    });
+    const devices = await driver.listDevices({ state: 'online' });
+
+    expect(devices.every((d) => d.state === 'online')).toBe(true);
+  });
+});
+
+// ─── Recording ───────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver startRecording / stopRecording', () => {
+  test('startRecording calls startFrameCapture on the socket', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
+    await driver.startRecording({ output: '/tmp/out.mp4' });
+    expect(ioSocket.isCapturing).toBe(true);
+  });
+
+  test('stopRecording returns { output, duration: 0 } when no frames were captured', async () => {
+    const { driver } = createDriverWithSession();
+    await driver.startRecording({ output: '/tmp/out.mp4' });
+    const result = await driver.stopRecording();
+
+    expect(result.output).toBe('/tmp/out.mp4');
+    expect(result.duration).toBe(0);
+  });
+
+  test('stopRecording throws when called without prior startRecording', async () => {
+    const { driver } = createDriverWithSession();
+    await expect(driver.stopRecording()).rejects.toThrow('startRecording');
+  });
+});
+
+// ─── View hierarchy ───────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.getViewHierarchy()', () => {
+  test('calls executeShellCommand with uiautomator dump on Android', async () => {
+    const { driver, restCalls } = createDriverWithSession({
+      platform: 'android',
+      restResponses: { executeShellCommand: '<?xml version="1.0"?><hierarchy />' },
+    });
+    await driver.getViewHierarchy();
+
+    const call = restCalls.find((c) => c.method === 'executeShellCommand');
+    expect((call?.args[1] as string)).toContain('uiautomator dump');
+  });
+
+  test('parses uiautomator XML into ViewNode array on Android', async () => {
+    const xml = `<?xml version="1.0"?>
+<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][1080,1920]" enabled="true" />
+</hierarchy>`;
+    const { driver } = createDriverWithSession({
+      platform: 'android',
+      restResponses: { executeShellCommand: xml },
+    });
+    const nodes = await driver.getViewHierarchy();
+
+    expect(nodes.length).toBeGreaterThan(0);
+    expect(nodes[0].type).toBe('hierarchy');
+  });
+
+  test('delegates to WDA getSource on iOS', async () => {
+    const wdaNodes: ViewNode[] = [{ type: 'XCUIElementTypeWindow', isVisible: true, isEnabled: true, bounds: { x: 0, y: 0, width: 390, height: 844 }, children: [] }];
+    const { driver, wda } = createDriverWithSession({
+      platform: 'ios',
+      wdaResponses: { getSource: wdaNodes },
+    });
+    const nodes = await driver.getViewHierarchy();
+
+    expect(wda!.calls.find((c) => c.method === 'getSource')).toBeDefined();
+    expect(nodes).toEqual(wdaNodes);
+  });
+});
+
+// ─── waitForActive ────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.waitForActive()', () => {
+  function makeDriver(allocationTimeout?: number) {
+    return new SauceLabsDriver({
+      username: 'u',
+      accessKey: 'k',
+      ...(allocationTimeout !== undefined ? { allocationTimeout } : {}),
+    });
+  }
+
+  function fakeRestReturning(states: Array<{ state: string; links?: Record<string, string> }>) {
+    let i = 0;
+    return {
+      getSession: async (_id: string) => {
+        const entry = states[Math.min(i++, states.length - 1)];
+        return { id: 'sess-1', state: entry.state, links: entry.links };
+      },
+    };
+  }
+
+  test('returns session when state is ACTIVE and links are present', async () => {
+    const driver = makeDriver();
+    // Override setTimeout so the test does not actually sleep 5s.
+    const origTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
+    try {
+      const rest = fakeRestReturning([
+        { state: 'ACTIVE', links: { ioWebsocketUrl: 'wss://io', eventsWebsocketUrl: 'wss://ev' } },
+      ]);
+      const session = await (driver as any).waitForActive(rest, 'sess-1');
+      expect(session.state).toBe('ACTIVE');
+    } finally {
+      (globalThis as any).setTimeout = origTimeout;
+    }
+  });
+
+  test('keeps polling when ACTIVE but links are missing', async () => {
+    const driver = makeDriver();
+    const origTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
+    try {
+      const rest = fakeRestReturning([
+        { state: 'ACTIVE' },
+        { state: 'ACTIVE' },
+        { state: 'ACTIVE', links: { ioWebsocketUrl: 'wss://io', eventsWebsocketUrl: 'wss://ev' } },
+      ]);
+      const session = await (driver as any).waitForActive(rest, 'sess-1');
+      expect(session.links?.ioWebsocketUrl).toBe('wss://io');
+    } finally {
+      (globalThis as any).setTimeout = origTimeout;
+    }
+  });
+
+  test('throws immediately on ERRORED state', async () => {
+    const driver = makeDriver();
+    const origTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
+    try {
+      const rest = fakeRestReturning([{ state: 'ERRORED' }]);
+      await expect((driver as any).waitForActive(rest, 'sess-1')).rejects.toThrow('ERRORED');
+    } finally {
+      (globalThis as any).setTimeout = origTimeout;
+    }
+  });
+
+  test('throws immediately on CLOSED state', async () => {
+    const driver = makeDriver();
+    const origTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
+    try {
+      const rest = fakeRestReturning([{ state: 'CLOSED' }]);
+      await expect((driver as any).waitForActive(rest, 'sess-1')).rejects.toThrow('CLOSED');
+    } finally {
+      (globalThis as any).setTimeout = origTimeout;
+    }
+  });
+
+  test('throws timeout error when deadline is exceeded', async () => {
+    const driver = makeDriver(0); // zero-length timeout → deadline already passed
+    const origTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
+    try {
+      const rest = fakeRestReturning([{ state: 'PENDING' }]);
+      await expect((driver as any).waitForActive(rest, 'sess-1')).rejects.toThrow('Timed out');
+    } finally {
+      (globalThis as any).setTimeout = origTimeout;
+    }
+  });
+});
+
+// ─── swipe ────────────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.swipe()', () => {
+  test('sends touch down, move sequence, then touch up', async () => {
+    const { driver, ioSocket } = createDriverWithSession({
+      resolutionWidth: 1080,
+      resolutionHeight: 1920,
+      pixelsPerPoint: 1,
+    });
+    await driver.swipe('up');
+
+    const actions = ioSocket.touchCalls.map((c) => c.action);
+    expect(actions[0]).toBe('d');
+    expect(actions[actions.length - 1]).toBe('u');
+    expect(actions.includes('m')).toBe(true);
+  });
+});

--- a/packages/driver-saucelabs/src/driver.test.ts
+++ b/packages/driver-saucelabs/src/driver.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { AppInfo, ViewNode } from '@mobilewright/protocol';
-import { SauceLabsDriver } from './driver.js';
+import { SauceLabsDriver, waitForActiveSession } from './driver.js';
 import type { TouchPoint } from './device-control-socket.js';
 
 // ─── Fake helpers ────────────────────────────────────────────────────────────
@@ -91,6 +91,7 @@ interface SessionOptions {
   currentOrientation?: 'PORTRAIT' | 'LANDSCAPE';
   restResponses?: Record<string, unknown>;
   wdaResponses?: Record<string, unknown>;
+  ownsSession?: boolean;
 }
 
 /**
@@ -106,6 +107,7 @@ function createDriverWithSession(opts: SessionOptions = {}) {
 
   (driver as any).session = {
     sauceSessionId: 'sess-123',
+    ownsSession: opts.ownsSession ?? true,
     platform,
     deviceId: 'iPhone_15_real',
     resolutionWidth: opts.resolutionWidth ?? 1170,
@@ -286,6 +288,36 @@ test.describe('SauceLabsDriver.tap()', () => {
     expect(ioSocket.touchCalls[0].cw).toBe(1920);
     expect(ioSocket.touchCalls[0].ch).toBe(1080);
     expect(ioSocket.touchCalls[0].orientation).toBe(1);
+  });
+
+  test('on iOS, scales pixel resolution down to points by pixelsPerPoint (WDA bounds are point-space)', async () => {
+    const { driver, ioSocket } = createDriverWithSession({
+      platform: 'ios',
+      resolutionWidth: 1170,
+      resolutionHeight: 2532,
+      pixelsPerPoint: 3,
+      currentOrientation: 'PORTRAIT',
+    });
+    await driver.tap(195, 768);
+
+    expect(ioSocket.touchCalls[0].cw).toBe(390);
+    expect(ioSocket.touchCalls[0].ch).toBe(844);
+    // x/y themselves are passed through unchanged — they already come in as points.
+    expect(ioSocket.touchCalls[0].points[0]).toMatchObject({ x: 195, y: 768 });
+  });
+
+  test('on Android, does not scale canvas dimensions even if pixelsPerPoint is not 1 (uiautomator bounds are already pixel-space)', async () => {
+    const { driver, ioSocket } = createDriverWithSession({
+      platform: 'android',
+      resolutionWidth: 1080,
+      resolutionHeight: 2400,
+      pixelsPerPoint: 2.75,
+      currentOrientation: 'PORTRAIT',
+    });
+    await driver.tap(540, 1200);
+
+    expect(ioSocket.touchCalls[0].cw).toBe(1080);
+    expect(ioSocket.touchCalls[0].ch).toBe(2400);
   });
 });
 
@@ -626,6 +658,39 @@ test.describe('SauceLabsDriver.applyDeviceSettings()', () => {
   });
 });
 
+// ─── Disconnect ──────────────────────────────────────────────────────────────
+
+test.describe('SauceLabsDriver.disconnect()', () => {
+  test('deletes the Sauce Labs session when this driver created it', async () => {
+    const { driver, restCalls } = createDriverWithSession({ ownsSession: true });
+    await driver.disconnect();
+
+    const call = restCalls.find((c) => c.method === 'deleteSession');
+    expect(call?.args[0]).toBe('sess-123');
+  });
+
+  test('leaves the Sauce Labs session alive when this driver only attached to it', async () => {
+    const { driver, restCalls } = createDriverWithSession({ ownsSession: false });
+    await driver.disconnect();
+
+    const call = restCalls.find((c) => c.method === 'deleteSession');
+    expect(call).toBeUndefined();
+  });
+
+  test('still closes local sockets and WDA when not owning the session', async () => {
+    const { driver, ioSocket, wda } = createDriverWithSession({ ownsSession: false, platform: 'ios' });
+    let ioClosed = false;
+    ioSocket.disconnect = async () => { ioClosed = true; };
+    let wdaClosed = false;
+    wda!.close = async () => { wdaClosed = true; };
+
+    await driver.disconnect();
+
+    expect(ioClosed).toBe(true);
+    expect(wdaClosed).toBe(true);
+  });
+});
+
 // ─── Device list ─────────────────────────────────────────────────────────────
 
 test.describe('SauceLabsDriver.listDevices()', () => {
@@ -749,15 +814,7 @@ test.describe('SauceLabsDriver.getViewHierarchy()', () => {
 
 // ─── waitForActive ────────────────────────────────────────────────────────────
 
-test.describe('SauceLabsDriver.waitForActive()', () => {
-  function makeDriver(allocationTimeout?: number) {
-    return new SauceLabsDriver({
-      username: 'u',
-      accessKey: 'k',
-      ...(allocationTimeout !== undefined ? { allocationTimeout } : {}),
-    });
-  }
-
+test.describe('waitForActiveSession()', () => {
   function fakeRestReturning(states: Array<{ state: string; links?: Record<string, string> }>) {
     let i = 0;
     return {
@@ -769,7 +826,6 @@ test.describe('SauceLabsDriver.waitForActive()', () => {
   }
 
   test('returns session when state is ACTIVE and links are present', async () => {
-    const driver = makeDriver();
     // Override setTimeout so the test does not actually sleep 5s.
     const origTimeout = globalThis.setTimeout;
     (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
@@ -777,7 +833,7 @@ test.describe('SauceLabsDriver.waitForActive()', () => {
       const rest = fakeRestReturning([
         { state: 'ACTIVE', links: { ioWebsocketUrl: 'wss://io', eventsWebsocketUrl: 'wss://ev' } },
       ]);
-      const session = await (driver as any).waitForActive(rest, 'sess-1');
+      const session = await waitForActiveSession(rest as any, 'sess-1', 60_000);
       expect(session.state).toBe('ACTIVE');
     } finally {
       (globalThis as any).setTimeout = origTimeout;
@@ -785,7 +841,6 @@ test.describe('SauceLabsDriver.waitForActive()', () => {
   });
 
   test('keeps polling when ACTIVE but links are missing', async () => {
-    const driver = makeDriver();
     const origTimeout = globalThis.setTimeout;
     (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
     try {
@@ -794,7 +849,7 @@ test.describe('SauceLabsDriver.waitForActive()', () => {
         { state: 'ACTIVE' },
         { state: 'ACTIVE', links: { ioWebsocketUrl: 'wss://io', eventsWebsocketUrl: 'wss://ev' } },
       ]);
-      const session = await (driver as any).waitForActive(rest, 'sess-1');
+      const session = await waitForActiveSession(rest as any, 'sess-1', 60_000);
       expect(session.links?.ioWebsocketUrl).toBe('wss://io');
     } finally {
       (globalThis as any).setTimeout = origTimeout;
@@ -802,36 +857,34 @@ test.describe('SauceLabsDriver.waitForActive()', () => {
   });
 
   test('throws immediately on ERRORED state', async () => {
-    const driver = makeDriver();
     const origTimeout = globalThis.setTimeout;
     (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
     try {
       const rest = fakeRestReturning([{ state: 'ERRORED' }]);
-      await expect((driver as any).waitForActive(rest, 'sess-1')).rejects.toThrow('ERRORED');
+      await expect(waitForActiveSession(rest as any, 'sess-1', 60_000)).rejects.toThrow('ERRORED');
     } finally {
       (globalThis as any).setTimeout = origTimeout;
     }
   });
 
   test('throws immediately on CLOSED state', async () => {
-    const driver = makeDriver();
     const origTimeout = globalThis.setTimeout;
     (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
     try {
       const rest = fakeRestReturning([{ state: 'CLOSED' }]);
-      await expect((driver as any).waitForActive(rest, 'sess-1')).rejects.toThrow('CLOSED');
+      await expect(waitForActiveSession(rest as any, 'sess-1', 60_000)).rejects.toThrow('CLOSED');
     } finally {
       (globalThis as any).setTimeout = origTimeout;
     }
   });
 
   test('throws timeout error when deadline is exceeded', async () => {
-    const driver = makeDriver(0); // zero-length timeout → deadline already passed
     const origTimeout = globalThis.setTimeout;
     (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => origTimeout(fn, 0);
     try {
       const rest = fakeRestReturning([{ state: 'PENDING' }]);
-      await expect((driver as any).waitForActive(rest, 'sess-1')).rejects.toThrow('Timed out');
+      // zero-length timeout → deadline already passed
+      await expect(waitForActiveSession(rest as any, 'sess-1', 0)).rejects.toThrow('Timed out');
     } finally {
       (globalThis as any).setTimeout = origTimeout;
     }

--- a/packages/driver-saucelabs/src/driver.test.ts
+++ b/packages/driver-saucelabs/src/driver.test.ts
@@ -17,18 +17,21 @@ function createFakeIoSocket() {
   const touchCalls: TouchCall[] = [];
   const keyCalls: string[] = [];
   let capturing = false;
-  let frames: Buffer[] = [];
+  let frames: { frame: Buffer; ts: number }[] = [];
+  let captureEndTs = 0;
 
   return {
     touchCalls,
     keyCalls,
-    setFramesToReturn(f: Buffer[]) { frames = f; },
+    setFramesToReturn(f: { frame: Buffer; ts: number }[]) { frames = f; },
+    setCaptureEndTs(ts: number) { captureEndTs = ts; },
     sendTouch(action: 'd' | 'm' | 'u', points: TouchPoint[], cw: number, ch: number, orientation: 0 | 1) {
       touchCalls.push({ action, points, cw, ch, orientation });
     },
     sendKey(key: string) { keyCalls.push(key); },
     startFrameCapture() { capturing = true; },
     stopFrameCapture() { const f = frames; capturing = false; return f; },
+    getCaptureEndTs() { return captureEndTs; },
     connect: async () => {},
     disconnect: async () => {},
     get isCapturing() { return capturing; },
@@ -520,7 +523,10 @@ test.describe('SauceLabsDriver.terminateApp()', () => {
 test.describe('SauceLabsDriver.installApp()', () => {
   test('uploads file to storage then calls installApp REST', async () => {
     const { driver, restCalls } = createDriverWithSession({
-      restResponses: { uploadToStorage: 'storage:uuid-abc' },
+      restResponses: {
+        uploadToStorage: 'storage:uuid-abc',
+        installApp: { status: 'FINISHED' },
+      },
     });
     await driver.installApp('/path/to/app.apk');
 

--- a/packages/driver-saucelabs/src/driver.test.ts
+++ b/packages/driver-saucelabs/src/driver.test.ts
@@ -355,18 +355,11 @@ test.describe('SauceLabsDriver.longPress()', () => {
 });
 
 test.describe('SauceLabsDriver.clearText()', () => {
-  test('sends cmd+a then Backspace on iOS', async () => {
-    const { driver, ioSocket } = createDriverWithSession({ platform: 'ios' });
+  test('sends select-all (a) then Backspace', async () => {
+    const { driver, ioSocket } = createDriverWithSession();
     await driver.clearText();
 
-    expect(ioSocket.keyCalls).toEqual(['cmd+a', 'Backspace']);
-  });
-
-  test('sends ctrl+a then Backspace on Android', async () => {
-    const { driver, ioSocket } = createDriverWithSession({ platform: 'android' });
-    await driver.clearText();
-
-    expect(ioSocket.keyCalls).toEqual(['ctrl+a', 'Backspace']);
+    expect(ioSocket.keyCalls).toEqual(['a', 'Backspace']);
   });
 });
 

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -88,6 +88,9 @@ const BUTTON_WDA: Partial<Record<HardwareButton, string>> = {
 
 interface ActiveSession {
   sauceSessionId: string;
+  /** True if this driver created the Sauce Labs session (and must delete it on disconnect);
+   * false if it only attached to a session created elsewhere (e.g. by the device pool allocator). */
+  ownsSession: boolean;
   platform: Platform;
   deviceId: string;
   resolutionWidth: number;
@@ -97,6 +100,45 @@ interface ActiveSession {
   ioSocket: DeviceControlSocket;
   companionSocket: CompanionSocket;
   wdaClient: WdaClient | null;
+}
+
+/** Polls a Sauce Labs session every 5 seconds until it is ACTIVE with control links, or throws
+ * on timeout or terminal error. */
+export async function waitForActiveSession(
+  rest: RestClient,
+  sessionId: string,
+  timeout: number,
+  opts: { skipInitialDelay?: boolean } = {},
+): Promise<import('./rest-client.js').Session> {
+  const pollInterval = 5_000;
+  const deadline = Date.now() + timeout;
+
+  // Device allocation takes at least several seconds — sleep before the first poll,
+  // unless the caller already knows the session is likely active (e.g. attaching to
+  // a session the pool already waited on).
+  if (!opts.skipInitialDelay) {
+    await new Promise((r) => setTimeout(r, pollInterval));
+  }
+
+  while (Date.now() < deadline) {
+    const s = await rest.getSession(sessionId);
+    const hasLinks = !!(s.links?.ioWebsocketUrl && s.links?.eventsWebsocketUrl);
+    debug('polling session %s state=%s links=%s', sessionId, s.state, hasLinks);
+    if (s.state === 'ACTIVE' && hasLinks) return s;
+    if (s.state === 'ERRORED' || s.state === 'CLOSED') {
+      throw new Error(`Session ${sessionId} reached terminal state: ${s.state}`);
+    }
+    await new Promise((r) => setTimeout(r, pollInterval));
+  }
+  throw new Error(`Timed out waiting for session ${sessionId} to become ACTIVE`);
+}
+
+function resolveCredentials(options: SauceLabsDriverOptions): { username: string; accessKey: string } {
+  const username = options.username ?? process.env['SAUCE_USERNAME'];
+  const accessKey = options.accessKey ?? process.env['SAUCE_ACCESS_KEY'];
+  if (!username) throw new Error('Sauce Labs username is required. Set options.username or SAUCE_USERNAME env var.');
+  if (!accessKey) throw new Error('Sauce Labs access key is required. Set options.accessKey or SAUCE_ACCESS_KEY env var.');
+  return { username, accessKey };
 }
 
 // ─── Helper parsers ───────────────────────────────────────────────────────────
@@ -151,28 +193,29 @@ export class SauceLabsDriver implements MobilewrightDriver {
 
   constructor(options: SauceLabsDriverOptions = {}) {
     this.options = options;
-    const username = options.username ?? process.env['SAUCE_USERNAME'];
-    const accessKey = options.accessKey ?? process.env['SAUCE_ACCESS_KEY'];
-    if (!username) throw new Error('Sauce Labs username is required. Set options.username or SAUCE_USERNAME env var.');
-    if (!accessKey) throw new Error('Sauce Labs access key is required. Set options.accessKey or SAUCE_ACCESS_KEY env var.');
+    const { username, accessKey } = resolveCredentials(options);
     this.username = username;
     this.accessKey = accessKey;
   }
 
   // ─── Connection ─────────────────────────────────────────────────────────────
 
-  /** Allocates a real device on Sauce Labs, waits for it to become active, and opens the device control and companion WebSocket channels. */
-  async connect(config: ConnectionConfig): Promise<Session> {
-    const rest = new RestClient(
-      this.username,
-      this.accessKey,
-      this.options.region ?? 'us-west-1',
-    );
+  /**
+   * Reserves a device on Sauce Labs and waits for the session to become ACTIVE, without
+   * opening any device control sockets. Intended for the device pool allocator, which only
+   * needs to resolve and hold a device — the returned sessionId is later passed to connect()
+   * via `ConnectionConfig.sessionId` so the actual test worker can attach to the same session
+   * instead of allocating a second device. Pair with `releaseSession()`.
+   */
+  static async allocateSession(
+    options: SauceLabsDriverOptions,
+    config: Pick<ConnectionConfig, 'platform' | 'deviceName'>,
+  ): Promise<{ sessionId: string; deviceId: string }> {
+    const { username, accessKey } = resolveCredentials(options);
+    const rest = new RestClient(username, accessKey, options.region ?? 'us-west-1');
+    const os: DeviceOs = config.platform === 'android' ? 'ANDROID' : 'IOS';
 
-    const platform = config.platform;
-    const os: DeviceOs = platform === 'android' ? 'ANDROID' : 'IOS';
-
-    debug('creating session platform=%s', platform);
+    debug('allocateSession platform=%s', config.platform);
     const creation = await rest.createSession({
       device: {
         os,
@@ -180,19 +223,71 @@ export class SauceLabsDriver implements MobilewrightDriver {
           ? { deviceName: typeof config.deviceName === 'string' ? config.deviceName : config.deviceName.source }
           : {}),
       },
-      ...(this.options.sessionDuration
-        ? { configuration: { sessionDuration: this.options.sessionDuration } }
+      ...(options.sessionDuration
+        ? { configuration: { sessionDuration: options.sessionDuration } }
         : {}),
     });
+    debug('allocateSession created id=%s state=%s', creation.id, creation.state);
 
-    debug('session created id=%s state=%s', creation.id, creation.state);
+    const active = await waitForActiveSession(rest, creation.id, options.allocationTimeout ?? 300_000);
+    const deviceId = active.device?.descriptor ?? creation.id;
+    debug('allocateSession ACTIVE id=%s deviceId=%s', creation.id, deviceId);
+    return { sessionId: creation.id, deviceId };
+  }
 
-    // Poll until ACTIVE
-    const sauceSession = await this.waitForActive(rest, creation.id);
+  /** Deletes a session previously created via `allocateSession()`, releasing the device back to Sauce Labs. */
+  static async releaseSession(options: SauceLabsDriverOptions, sessionId: string): Promise<void> {
+    const { username, accessKey } = resolveCredentials(options);
+    const rest = new RestClient(username, accessKey, options.region ?? 'us-west-1');
+    await rest.deleteSession(sessionId);
+  }
+
+  /**
+   * Opens the device control and companion WebSocket channels for a Sauce Labs session.
+   * Creates a new session unless `config.sessionId` is given, in which case it attaches to
+   * an already-active session (e.g. one created via `allocateSession()`) instead of
+   * allocating a second device.
+   */
+  async connect(config: ConnectionConfig): Promise<Session> {
+    const rest = this.makeRest();
+
+    const platform = config.platform;
+    const os: DeviceOs = platform === 'android' ? 'ANDROID' : 'IOS';
+
+    let sauceSessionId: string;
+    const ownsSession = !config.sessionId;
+    if (config.sessionId) {
+      debug('attaching to existing session %s', config.sessionId);
+      sauceSessionId = config.sessionId;
+    } else {
+      debug('creating session platform=%s', platform);
+      const creation = await rest.createSession({
+        device: {
+          os,
+          ...(config.deviceName
+            ? { deviceName: typeof config.deviceName === 'string' ? config.deviceName : config.deviceName.source }
+            : {}),
+        },
+        ...(this.options.sessionDuration
+          ? { configuration: { sessionDuration: this.options.sessionDuration } }
+          : {}),
+      });
+      debug('session created id=%s state=%s', creation.id, creation.state);
+      sauceSessionId = creation.id;
+    }
+
+    // Poll until ACTIVE. Attached sessions were already waited on by the allocator, so skip
+    // the unconditional pre-poll delay in that case.
+    const sauceSession = await waitForActiveSession(
+      rest,
+      sauceSessionId,
+      this.options.allocationTimeout ?? 300_000,
+      { skipInitialDelay: !ownsSession },
+    );
     debug('session ACTIVE, descriptor=%s', sauceSession.device?.descriptor);
 
-    const descriptor = sauceSession.device?.descriptor ?? creation.id;
-    // waitForActive() guarantees links are present before returning.
+    const descriptor = sauceSession.device?.descriptor ?? sauceSessionId;
+    // waitForActiveSession() guarantees links are present before returning.
     const links = sauceSession.links!;
 
     // Fetch device descriptor for screen metrics
@@ -232,7 +327,8 @@ export class SauceLabsDriver implements MobilewrightDriver {
     }
 
     this.session = {
-      sauceSessionId: creation.id,
+      sauceSessionId,
+      ownsSession,
       platform,
       deviceId: descriptor,
       resolutionWidth,
@@ -241,7 +337,7 @@ export class SauceLabsDriver implements MobilewrightDriver {
       currentOrientation: defaultOrientation,
       ioSocket,
       companionSocket,
-      wdaClient: platform === 'ios' ? new WdaClient(rest, creation.id, this.options.iosWdaBundleId, wdaStorageRef) : null,
+      wdaClient: platform === 'ios' ? new WdaClient(rest, sauceSessionId, this.options.iosWdaBundleId, wdaStorageRef) : null,
     };
 
     companionSocket.onOrientationFinish((orientation) => {
@@ -251,32 +347,14 @@ export class SauceLabsDriver implements MobilewrightDriver {
       }
     });
 
-    return { deviceId: descriptor, platform };
+    return { deviceId: descriptor, platform, sessionId: sauceSessionId };
   }
 
-  /** Polls the session state every 5 seconds until the device is ACTIVE with control links, or throws on timeout or terminal error. */
-  private async waitForActive(rest: RestClient, sessionId: string): Promise<import('./rest-client.js').Session> {
-    const timeout = this.options.allocationTimeout ?? 300_000;
-    const pollInterval = 5_000;
-    const deadline = Date.now() + timeout;
-
-    // Device allocation takes at least several seconds — sleep before the first poll.
-    await new Promise((r) => setTimeout(r, pollInterval));
-
-    while (Date.now() < deadline) {
-      const s = await rest.getSession(sessionId);
-      const hasLinks = !!(s.links?.ioWebsocketUrl && s.links?.eventsWebsocketUrl);
-      debug('polling session %s state=%s links=%s', sessionId, s.state, hasLinks);
-      if (s.state === 'ACTIVE' && hasLinks) return s;
-      if (s.state === 'ERRORED' || s.state === 'CLOSED') {
-        throw new Error(`Session ${sessionId} reached terminal state: ${s.state}`);
-      }
-      await new Promise((r) => setTimeout(r, pollInterval));
-    }
-    throw new Error(`Timed out waiting for session ${sessionId} to become ACTIVE`);
-  }
-
-  /** Closes the WDA session (iOS), disconnects both WebSockets, and deletes the Sauce Labs session to release the device. */
+  /**
+   * Closes the WDA session (iOS) and disconnects both WebSockets. Only deletes the underlying
+   * Sauce Labs session (releasing the device) when this driver created it — a driver attached
+   * via `ConnectionConfig.sessionId` leaves the session alive for other callers to reuse.
+   */
   async disconnect(): Promise<void> {
     const session = this.requireSession();
     const rest = this.makeRest();
@@ -290,9 +368,11 @@ export class SauceLabsDriver implements MobilewrightDriver {
       session.companionSocket.disconnect(),
     ]);
 
-    await rest.deleteSession(session.sauceSessionId);
+    if (session.ownsSession) {
+      await rest.deleteSession(session.sauceSessionId);
+    }
     this.session = null;
-    debug('disconnected');
+    debug('disconnected (ownsSession=%s)', session.ownsSession);
   }
 
   // ─── Device settings ─────────────────────────────────────────────────────────
@@ -326,13 +406,27 @@ export class SauceLabsDriver implements MobilewrightDriver {
 
   // ─── Input ───────────────────────────────────────────────────────────────────
 
+  /**
+   * Canvas size and orientation flag used to normalize touch coordinates for
+   * sendTouch(). WDA reports iOS element bounds in points, so the canvas is
+   * scaled down from resolutionWidth/resolutionHeight (pixels) by pixelsPerPoint
+   * to match; Android's uiautomator bounds are already pixel-space and need no
+   * scaling.
+   */
+  private touchFrame(session: ActiveSession): { cw: number; ch: number; orientation: 0 | 1 } {
+    const scale = session.platform === 'ios' ? (session.pixelsPerPoint || 1) : 1;
+    const w = session.resolutionWidth / scale;
+    const h = session.resolutionHeight / scale;
+    const orientation: 0 | 1 = session.currentOrientation === 'LANDSCAPE' ? 1 : 0;
+    return orientation === 1 ? { cw: h, ch: w, orientation } : { cw: w, ch: h, orientation };
+  }
+
   /** Sends a touch-down then touch-up at the given logical coordinates over the device control socket. */
   async tap(x: number, y: number): Promise<void> {
-    const { ioSocket, resolutionWidth, resolutionHeight, currentOrientation } = this.requireSession();
-    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
-    const [cw, ch] = orientation === 1 ? [resolutionHeight, resolutionWidth] : [resolutionWidth, resolutionHeight];
-    ioSocket.sendTouch('d', [{ x, y, index: 0 }], cw, ch, orientation);
-    ioSocket.sendTouch('u', [{ x, y, index: 0 }], cw, ch, orientation);
+    const session = this.requireSession();
+    const { cw, ch, orientation } = this.touchFrame(session);
+    session.ioSocket.sendTouch('d', [{ x, y, index: 0 }], cw, ch, orientation);
+    session.ioSocket.sendTouch('u', [{ x, y, index: 0 }], cw, ch, orientation);
   }
 
   /** Performs two taps at the same coordinates with a 100 ms gap between them. */
@@ -344,12 +438,11 @@ export class SauceLabsDriver implements MobilewrightDriver {
 
   /** Holds a touch-down for the given duration (ms) before lifting, simulating a long press. */
   async longPress(x: number, y: number, duration = 500): Promise<void> {
-    const { ioSocket, resolutionWidth, resolutionHeight, currentOrientation } = this.requireSession();
-    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
-    const [cw, ch] = orientation === 1 ? [resolutionHeight, resolutionWidth] : [resolutionWidth, resolutionHeight];
-    ioSocket.sendTouch('d', [{ x, y, index: 0 }], cw, ch, orientation);
+    const session = this.requireSession();
+    const { cw, ch, orientation } = this.touchFrame(session);
+    session.ioSocket.sendTouch('d', [{ x, y, index: 0 }], cw, ch, orientation);
     await new Promise((r) => setTimeout(r, duration));
-    ioSocket.sendTouch('u', [{ x, y, index: 0 }], cw, ch, orientation);
+    session.ioSocket.sendTouch('u', [{ x, y, index: 0 }], cw, ch, orientation);
   }
 
   /** Types text via socket key events for ASCII; falls back to adb `input text` for non-ASCII on Android, or character-by-character on iOS. */
@@ -390,9 +483,8 @@ export class SauceLabsDriver implements MobilewrightDriver {
   /** Interpolates a swipe in the given direction as a series of touch-move events spread across the specified duration. */
   async swipe(direction: SwipeDirection, opts?: SwipeOptions): Promise<void> {
     const session = this.requireSession();
-    const { resolutionWidth: w, resolutionHeight: h, currentOrientation, ioSocket } = session;
-    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
-    const [cw, ch] = orientation === 1 ? [h, w] : [w, h];
+    const { ioSocket } = session;
+    const { cw, ch, orientation } = this.touchFrame(session);
 
     const centerX = cw / 2;
     const centerY = ch / 2;
@@ -430,9 +522,8 @@ export class SauceLabsDriver implements MobilewrightDriver {
   /** Replays a multi-pointer gesture by dispatching touch events for each pointer at their recorded timestamps. */
   async gesture(gestures: GestureSequence): Promise<void> {
     const session = this.requireSession();
-    const { resolutionWidth: w, resolutionHeight: h, currentOrientation, ioSocket } = session;
-    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
-    const [cw, ch] = orientation === 1 ? [h, w] : [w, h];
+    const { ioSocket } = session;
+    const { cw, ch, orientation } = this.touchFrame(session);
     const pointers = gestures.pointers;
 
     // Collect all unique timestamps, sorted
@@ -555,7 +646,7 @@ export class SauceLabsDriver implements MobilewrightDriver {
             if (!entry) continue;
             debug('launchApp install+launch %s status=%s', installationId, entry.status);
             if (entry.status === 'FINISHED') break;
-            if (entry.status === 'ERROR') throw new Error(`App launch via install failed for ${storageRef}`);
+            if (entry.status === 'ERROR') throw new Error(`App launch via install failed for ${storageRef}: ${JSON.stringify(entry)}`);
           }
         }
       } else {
@@ -603,7 +694,7 @@ export class SauceLabsDriver implements MobilewrightDriver {
       if (!entry) continue;
       debug('install %s status=%s', installationId, entry.status);
       if (entry.status === 'FINISHED') return;
-      if (entry.status === 'ERROR') throw new Error(`App installation failed for ${storageRef}`);
+      if (entry.status === 'ERROR') throw new Error(`App installation failed for ${storageRef}: ${JSON.stringify(entry)}`);
     }
     throw new Error(`Timed out waiting for app installation to complete: ${storageRef}`);
   }

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -585,7 +585,9 @@ export class SauceLabsDriver implements MobilewrightDriver {
     const rest = this.makeRest();
     const storageRef = filePathOrStorageRef.startsWith('storage:')
       ? filePathOrStorageRef
-      : await rest.uploadToStorage(filePathOrStorageRef);
+      : filePathOrStorageRef.startsWith('https://')
+        ? await rest.uploadUrlToStorage(filePathOrStorageRef)
+        : await rest.uploadToStorage(filePathOrStorageRef);
     this.lastInstalledStorageRef = storageRef;
     const result = await rest.installApp(sauceSessionId, storageRef);
     const installationId = result.installationId;

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -650,8 +650,10 @@ export class SauceLabsDriver implements MobilewrightDriver {
           }
         }
       } else {
-        const activityName = opts?.activity ?? `${bundleId}.MainActivity`;
-        await rest.launchApp(sauceSessionId, { packageName: bundleId, activityName });
+        await rest.launchApp(sauceSessionId, {
+          packageName: bundleId,
+          ...(opts?.activity ? { activityName: opts.activity } : {}),
+        });
       }
     } else {
       await rest.launchApp(sauceSessionId, { bundleId });

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -279,96 +279,97 @@ export class SauceLabsDriver implements MobilewrightDriver {
       sauceSessionId = creation.id;
     }
 
-    // Poll until ACTIVE. Attached sessions were already waited on by the allocator, so skip
-    // the unconditional pre-poll delay in that case.
-    const sauceSession = await waitForActiveSession(
-      rest,
-      sauceSessionId,
-      this.options.allocationTimeout ?? 300_000,
-      { skipInitialDelay: !ownsSession },
-    );
-    debug('session ACTIVE, descriptor=%s', sauceSession.device?.descriptor);
-
-    const descriptor = sauceSession.device?.descriptor ?? sauceSessionId;
-    // waitForActiveSession() guarantees links are present before returning.
-    const links = sauceSession.links!;
-
-    if (SHOW_LIVE_VIEW && links.liveViewUrl) {
-      console.log(`📱 Sauce Labs live view (${descriptor}): 🔗 ${links.liveViewUrl}`);
-    }
-
-    // Fetch device descriptor for screen metrics
-    let resolutionWidth = 1080;
-    let resolutionHeight = 1920;
-    let pixelsPerPoint = 1;
-    let defaultOrientation: 'PORTRAIT' | 'LANDSCAPE' = 'PORTRAIT';
-
+    // Everything below can fail before this.session is assigned, at which point disconnect()
+    // has nothing to clean up — so any failure in this block must release whatever we created
+    // (owned session, connected sockets) directly instead of leaking it.
+    let ioSocket: DeviceControlSocket | undefined;
+    let companionSocket: CompanionSocket | undefined;
     try {
-      const descriptors = await rest.listDevices();
-      const desc = descriptors.find((d) => d.id === descriptor);
-      if (desc) {
-        resolutionWidth = desc.resolutionWidth ?? resolutionWidth;
-        resolutionHeight = desc.resolutionHeight ?? resolutionHeight;
-        pixelsPerPoint = desc.pixelsPerPoint ?? pixelsPerPoint;
-        defaultOrientation = parseOrientation(desc.defaultOrientation);
+      // Poll until ACTIVE. Attached sessions were already waited on by the allocator, so skip
+      // the unconditional pre-poll delay in that case.
+      const sauceSession = await waitForActiveSession(
+        rest,
+        sauceSessionId,
+        this.options.allocationTimeout ?? 300_000,
+        { skipInitialDelay: !ownsSession },
+      );
+      debug('session ACTIVE, descriptor=%s', sauceSession.device?.descriptor);
+
+      const descriptor = sauceSession.device?.descriptor ?? sauceSessionId;
+      // waitForActiveSession() guarantees links are present before returning.
+      const links = sauceSession.links!;
+
+      if (SHOW_LIVE_VIEW && links.liveViewUrl) {
+        console.log(`📱 Sauce Labs live view (${descriptor}): 🔗 ${links.liveViewUrl}`);
       }
-    } catch (err) {
-      debug('failed to fetch device descriptor: %s', (err as Error).message);
-    }
 
-    const ioSocket = new DeviceControlSocket(links.ioWebsocketUrl, this.username, this.accessKey);
-    const companionSocket = new CompanionSocket(links.eventsWebsocketUrl, this.username, this.accessKey);
+      // Fetch device descriptor for screen metrics
+      let resolutionWidth = 1080;
+      let resolutionHeight = 1920;
+      let pixelsPerPoint = 1;
+      let defaultOrientation: 'PORTRAIT' | 'LANDSCAPE' = 'PORTRAIT';
 
-    try {
+      try {
+        const descriptors = await rest.listDevices();
+        const desc = descriptors.find((d) => d.id === descriptor);
+        if (desc) {
+          resolutionWidth = desc.resolutionWidth ?? resolutionWidth;
+          resolutionHeight = desc.resolutionHeight ?? resolutionHeight;
+          pixelsPerPoint = desc.pixelsPerPoint ?? pixelsPerPoint;
+          defaultOrientation = parseOrientation(desc.defaultOrientation);
+        }
+      } catch (err) {
+        debug('failed to fetch device descriptor: %s', (err as Error).message);
+      }
+
+      ioSocket = new DeviceControlSocket(links.ioWebsocketUrl, this.username, this.accessKey);
+      companionSocket = new CompanionSocket(links.eventsWebsocketUrl, this.username, this.accessKey);
       await Promise.all([ioSocket.connect(), companionSocket.connect()]);
+
+      let wdaStorageRef: string | undefined;
+      if (platform === 'ios') {
+        const wdaSource = this.options.iosWdaStorageRef ?? DEFAULT_WDA_URL;
+        if (wdaSource.startsWith('storage:')) {
+          wdaStorageRef = wdaSource;
+        } else {
+          debug('uploading WDA from URL: %s', wdaSource);
+          wdaStorageRef = await rest.uploadWdaToStorage(wdaSource);
+          debug('WDA ready at %s', wdaStorageRef);
+        }
+      }
+
+      this.session = {
+        sauceSessionId,
+        ownsSession,
+        platform,
+        deviceId: descriptor,
+        resolutionWidth,
+        resolutionHeight,
+        pixelsPerPoint,
+        currentOrientation: defaultOrientation,
+        ioSocket,
+        companionSocket,
+        wdaClient: platform === 'ios' ? new WdaClient(rest, sauceSessionId, this.options.iosWdaBundleId, wdaStorageRef) : null,
+      };
+
+      companionSocket.onOrientationFinish((orientation) => {
+        debug('orientation changed to %s', orientation);
+        if (this.session) {
+          this.session.currentOrientation = orientation;
+        }
+      });
+
+      return { deviceId: descriptor, platform, sessionId: sauceSessionId };
     } catch (err) {
-      // Clean up any successfully connected sockets before propagating the error
-      await ioSocket.disconnect().catch(() => {});
-      await companionSocket.disconnect().catch(() => {});
+      await ioSocket?.disconnect().catch(() => {});
+      await companionSocket?.disconnect().catch(() => {});
       if (ownsSession) {
-        // this.session is still unset, so disconnect() can't release the session we just
-        // created — delete it directly here instead of leaking it.
         await rest.deleteSession(sauceSessionId).catch((deleteErr) =>
-          debug('session cleanup error after socket connect failure: %s', (deleteErr as Error).message),
+          debug('session cleanup error after connect failure: %s', (deleteErr as Error).message),
         );
       }
       throw err;
     }
-
-    let wdaStorageRef: string | undefined;
-    if (platform === 'ios') {
-      const wdaSource = this.options.iosWdaStorageRef ?? DEFAULT_WDA_URL;
-      if (wdaSource.startsWith('storage:')) {
-        wdaStorageRef = wdaSource;
-      } else {
-        debug('uploading WDA from URL: %s', wdaSource);
-        wdaStorageRef = await rest.uploadWdaToStorage(wdaSource);
-        debug('WDA ready at %s', wdaStorageRef);
-      }
-    }
-
-    this.session = {
-      sauceSessionId,
-      ownsSession,
-      platform,
-      deviceId: descriptor,
-      resolutionWidth,
-      resolutionHeight,
-      pixelsPerPoint,
-      currentOrientation: defaultOrientation,
-      ioSocket,
-      companionSocket,
-      wdaClient: platform === 'ios' ? new WdaClient(rest, sauceSessionId, this.options.iosWdaBundleId, wdaStorageRef) : null,
-    };
-
-    companionSocket.onOrientationFinish((orientation) => {
-      debug('orientation changed to %s', orientation);
-      if (this.session) {
-        this.session.currentOrientation = orientation;
-      }
-    });
-
-    return { deviceId: descriptor, platform, sessionId: sauceSessionId };
   }
 
   /**

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -325,6 +325,13 @@ export class SauceLabsDriver implements MobilewrightDriver {
       // Clean up any successfully connected sockets before propagating the error
       await ioSocket.disconnect().catch(() => {});
       await companionSocket.disconnect().catch(() => {});
+      if (ownsSession) {
+        // this.session is still unset, so disconnect() can't release the session we just
+        // created — delete it directly here instead of leaking it.
+        await rest.deleteSession(sauceSessionId).catch((deleteErr) =>
+          debug('session cleanup error after socket connect failure: %s', (deleteErr as Error).message),
+        );
+      }
       throw err;
     }
 

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -1,0 +1,868 @@
+import { spawn } from 'node:child_process';
+import createDebug from 'debug';
+import type {
+  AppInfo,
+  ConnectionConfig,
+  DeviceInfo,
+  DeviceSettings,
+  GestureSequence,
+  HardwareButton,
+  LaunchOptions,
+  ListDevicesOptions,
+  MobilewrightDriver,
+  Orientation,
+  Platform,
+  RecordingOptions,
+  RecordingResult,
+  ScreenSize,
+  ScreenshotOptions,
+  Session,
+  SwipeDirection,
+  SwipeOptions,
+  ViewNode,
+} from '@mobilewright/protocol';
+import { RestClient, type Region, type DeviceOs } from './rest-client.js';
+import { DeviceControlSocket } from './device-control-socket.js';
+import { CompanionSocket } from './companion-socket.js';
+import { WdaClient } from './wda-client.js';
+
+const debug = createDebug('mw:driver-saucelabs');
+
+const DEFAULT_WDA_URL =
+  process.env['SAUCE_IOS_WDA_URL'] ??
+  'https://github.com/appium/WebDriverAgent/releases/download/v15.0.0/WebDriverAgentRunner-Runner.zip';
+
+export interface SauceLabsDriverOptions {
+  /** Falls back to SAUCE_USERNAME env var when omitted. */
+  username?: string;
+  /** Falls back to SAUCE_ACCESS_KEY env var when omitted. */
+  accessKey?: string;
+  region?: Region;
+  /** ms to wait for session ACTIVE, default 300_000 */
+  allocationTimeout?: number;
+  /** ISO-8601 duration e.g. 'PT1H' */
+  sessionDuration?: string;
+  /** iOS only: custom WDA fork bundle ID passed to launchWebDriverAgent. Omit to use the Sauce Labs default WDA. */
+  iosWdaBundleId?: string;
+  /**
+   * iOS only: overrides the WDA runner zip used for iOS sessions.
+   * Accepts a `storage:<id>` ref for a file already uploaded to Sauce Storage,
+   * or an `https://` URL that the driver will download and upload automatically.
+   * When omitted the driver uses the URL from the `SAUCE_IOS_WDA_URL` env var,
+   * falling back to the pinned default WDA release.
+   */
+  iosWdaStorageRef?: string;
+}
+
+// ─── Hardware button → socket key mapping ────────────────────────────────────
+
+const BUTTON_KEY: Partial<Record<HardwareButton, string>> = {
+  HOME: 'Sauce_Home_Key',
+  BACK: 'Sauce_Back_Key',
+  APP_SWITCH: 'Sauce_Menu_Key',
+};
+
+// Android key events via shell
+const BUTTON_KEYEVENT: Partial<Record<HardwareButton, number>> = {
+  POWER: 26,
+  VOLUME_UP: 24,
+  VOLUME_DOWN: 25,
+  LOCK: 26,
+  ENTER: 66,
+  DPAD_UP: 19,
+  DPAD_DOWN: 20,
+  DPAD_LEFT: 21,
+  DPAD_RIGHT: 22,
+  DPAD_CENTER: 23,
+};
+
+// WDA button names for iOS
+const BUTTON_WDA: Partial<Record<HardwareButton, string>> = {
+  VOLUME_UP: 'volumeUp',
+  VOLUME_DOWN: 'volumeDown',
+  POWER: 'power',
+  LOCK: 'power',
+};
+
+// ─── Internal session state ───────────────────────────────────────────────────
+
+interface ActiveSession {
+  sauceSessionId: string;
+  platform: Platform;
+  deviceId: string;
+  resolutionWidth: number;
+  resolutionHeight: number;
+  pixelsPerPoint: number;
+  currentOrientation: 'PORTRAIT' | 'LANDSCAPE';
+  ioSocket: DeviceControlSocket;
+  companionSocket: CompanionSocket;
+  wdaClient: WdaClient | null;
+}
+
+// ─── Helper parsers ───────────────────────────────────────────────────────────
+
+function parseOrientation(value: string | undefined): 'PORTRAIT' | 'LANDSCAPE' {
+  return value?.toUpperCase() === 'LANDSCAPE' ? 'LANDSCAPE' : 'PORTRAIT';
+}
+
+function sauceOrientationToProtocol(o: 'PORTRAIT' | 'LANDSCAPE'): Orientation {
+  return o === 'LANDSCAPE' ? 'landscape' : 'portrait';
+}
+
+function protocolOrientationToSauce(o: Orientation): 'PORTRAIT' | 'LANDSCAPE' {
+  return o === 'landscape' ? 'LANDSCAPE' : 'PORTRAIT';
+}
+
+// Parse Android `pm list packages -3` output into AppInfo[]
+function parsePmListPackages(stdout: string): AppInfo[] {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('package:'))
+    .map((line) => ({ bundleId: line.slice('package:'.length).trim() }));
+}
+
+// Parse foreground app from `dumpsys window windows | grep mCurrentFocus` output.
+// Format: mCurrentFocus=Window{... <package>/<activity>}
+// Fallback: `dumpsys activity activities | grep mResumedActivity`
+// Format: mResumedActivity=ActivityRecord{... <package>/<activity>}
+function parseForegroundApp(stdout: string): AppInfo {
+  for (const line of stdout.split('\n')) {
+    // mCurrentFocus format (window manager, reliable across all Android versions)
+    const winMatch = line.match(/mCurrentFocus=Window\{[^}]+ ([^/\s}]+)\//);
+    if (winMatch) return { bundleId: winMatch[1] };
+    // mResumedActivity format (activity manager)
+    const actMatch = line.match(/mResumedActivity[=: ]+ActivityRecord\{[^ ]+ [^ ]+ ([^/]+)\//);
+    if (actMatch) return { bundleId: actMatch[1] };
+  }
+  return { bundleId: '' };
+}
+
+// ─── Driver ───────────────────────────────────────────────────────────────────
+
+/** Mobilewright driver that controls real devices via the Sauce Labs Real Device Cloud API. */
+export class SauceLabsDriver implements MobilewrightDriver {
+  private session: ActiveSession | null = null;
+  private readonly options: SauceLabsDriverOptions;
+  private readonly username: string;
+  private readonly accessKey: string;
+  private recordingOptions: RecordingOptions | null = null;
+  private lastInstalledStorageRef: string | null = null;
+
+  constructor(options: SauceLabsDriverOptions = {}) {
+    this.options = options;
+    const username = options.username ?? process.env['SAUCE_USERNAME'];
+    const accessKey = options.accessKey ?? process.env['SAUCE_ACCESS_KEY'];
+    if (!username) throw new Error('Sauce Labs username is required. Set options.username or SAUCE_USERNAME env var.');
+    if (!accessKey) throw new Error('Sauce Labs access key is required. Set options.accessKey or SAUCE_ACCESS_KEY env var.');
+    this.username = username;
+    this.accessKey = accessKey;
+  }
+
+  // ─── Connection ─────────────────────────────────────────────────────────────
+
+  /** Allocates a real device on Sauce Labs, waits for it to become active, and opens the device control and companion WebSocket channels. */
+  async connect(config: ConnectionConfig): Promise<Session> {
+    const rest = new RestClient(
+      this.username,
+      this.accessKey,
+      this.options.region ?? 'us-west-1',
+    );
+
+    const platform = config.platform;
+    const os: DeviceOs = platform === 'android' ? 'ANDROID' : 'IOS';
+
+    debug('creating session platform=%s', platform);
+    const creation = await rest.createSession({
+      device: {
+        os,
+        ...(config.deviceName
+          ? { deviceName: typeof config.deviceName === 'string' ? config.deviceName : config.deviceName.source }
+          : {}),
+      },
+      ...(this.options.sessionDuration
+        ? { configuration: { sessionDuration: this.options.sessionDuration } }
+        : {}),
+    });
+
+    debug('session created id=%s state=%s', creation.id, creation.state);
+
+    // Poll until ACTIVE
+    const sauceSession = await this.waitForActive(rest, creation.id);
+    debug('session ACTIVE, descriptor=%s', sauceSession.device?.descriptor);
+
+    const descriptor = sauceSession.device?.descriptor ?? creation.id;
+    // waitForActive() guarantees links are present before returning.
+    const links = sauceSession.links!;
+
+    // Fetch device descriptor for screen metrics
+    let resolutionWidth = 1080;
+    let resolutionHeight = 1920;
+    let pixelsPerPoint = 1;
+    let defaultOrientation: 'PORTRAIT' | 'LANDSCAPE' = 'PORTRAIT';
+
+    try {
+      const descriptors = await rest.listDevices();
+      const desc = descriptors.find((d) => d.id === descriptor);
+      if (desc) {
+        resolutionWidth = desc.resolutionWidth ?? resolutionWidth;
+        resolutionHeight = desc.resolutionHeight ?? resolutionHeight;
+        pixelsPerPoint = desc.pixelsPerPoint ?? pixelsPerPoint;
+        defaultOrientation = parseOrientation(desc.defaultOrientation);
+      }
+    } catch (err) {
+      debug('failed to fetch device descriptor: %s', (err as Error).message);
+    }
+
+    const ioSocket = new DeviceControlSocket(links.ioWebsocketUrl, this.username, this.accessKey);
+    const companionSocket = new CompanionSocket(links.eventsWebsocketUrl, this.username, this.accessKey);
+
+    await Promise.all([ioSocket.connect(), companionSocket.connect()]);
+
+    let wdaStorageRef: string | undefined;
+    if (platform === 'ios') {
+      const wdaSource = this.options.iosWdaStorageRef ?? DEFAULT_WDA_URL;
+      if (wdaSource.startsWith('storage:')) {
+        wdaStorageRef = wdaSource;
+      } else {
+        debug('uploading WDA from URL: %s', wdaSource);
+        wdaStorageRef = await rest.uploadWdaToStorage(wdaSource);
+        debug('WDA ready at %s', wdaStorageRef);
+      }
+    }
+
+    this.session = {
+      sauceSessionId: creation.id,
+      platform,
+      deviceId: descriptor,
+      resolutionWidth,
+      resolutionHeight,
+      pixelsPerPoint,
+      currentOrientation: defaultOrientation,
+      ioSocket,
+      companionSocket,
+      wdaClient: platform === 'ios' ? new WdaClient(rest, creation.id, this.options.iosWdaBundleId, wdaStorageRef) : null,
+    };
+
+    companionSocket.onOrientationFinish((orientation) => {
+      debug('orientation changed to %s', orientation);
+      if (this.session) {
+        this.session.currentOrientation = orientation;
+      }
+    });
+
+    return { deviceId: descriptor, platform };
+  }
+
+  /** Polls the session state every 5 seconds until the device is ACTIVE with control links, or throws on timeout or terminal error. */
+  private async waitForActive(rest: RestClient, sessionId: string): Promise<import('./rest-client.js').Session> {
+    const timeout = this.options.allocationTimeout ?? 300_000;
+    const pollInterval = 5_000;
+    const deadline = Date.now() + timeout;
+
+    // Device allocation takes at least several seconds — sleep before the first poll.
+    await new Promise((r) => setTimeout(r, pollInterval));
+
+    while (Date.now() < deadline) {
+      const s = await rest.getSession(sessionId);
+      const hasLinks = !!(s.links?.ioWebsocketUrl && s.links?.eventsWebsocketUrl);
+      debug('polling session %s state=%s links=%s', sessionId, s.state, hasLinks);
+      if (s.state === 'ACTIVE' && hasLinks) return s;
+      if (s.state === 'ERRORED' || s.state === 'CLOSED') {
+        throw new Error(`Session ${sessionId} reached terminal state: ${s.state}`);
+      }
+      await new Promise((r) => setTimeout(r, pollInterval));
+    }
+    throw new Error(`Timed out waiting for session ${sessionId} to become ACTIVE`);
+  }
+
+  /** Closes the WDA session (iOS), disconnects both WebSockets, and deletes the Sauce Labs session to release the device. */
+  async disconnect(): Promise<void> {
+    const session = this.requireSession();
+    const rest = this.makeRest();
+
+    if (session.wdaClient) {
+      await session.wdaClient.close().catch((err) => debug('wda close error: %s', err.message));
+    }
+
+    await Promise.all([
+      session.ioSocket.disconnect(),
+      session.companionSocket.disconnect(),
+    ]);
+
+    await rest.deleteSession(session.sauceSessionId);
+    this.session = null;
+    debug('disconnected');
+  }
+
+  // ─── Device settings ─────────────────────────────────────────────────────────
+
+  /** Applies device-level settings; the animations toggle is Android-only and silently ignored on iOS. */
+  async applyDeviceSettings(settings: DeviceSettings): Promise<void> {
+    const { sauceSessionId, platform } = this.requireSession();
+    const rest = this.makeRest();
+    if (settings.animations !== undefined && platform === 'android') {
+      await rest.applySettings(sauceSessionId, {
+        animations: settings.animations === 'on',
+      });
+    }
+    // animations not supported on iOS — silently no-op
+  }
+
+  // ─── UI hierarchy ─────────────────────────────────────────────────────────────
+
+  /** Returns the full UI tree — parsed from a uiautomator dump on Android, or from WDA's XML source on iOS. */
+  async getViewHierarchy(): Promise<ViewNode[]> {
+    const session = this.requireSession();
+    const rest = this.makeRest();
+    if (session.platform === 'android') {
+      const stdout = await rest.executeShellCommand(session.sauceSessionId, 'uiautomator dump /dev/tty');
+      return parseUiautomatorXml(stdout);
+    } else {
+      const wda = this.requireWda(session);
+      return wda.getSource();
+    }
+  }
+
+  // ─── Input ───────────────────────────────────────────────────────────────────
+
+  /** Sends a touch-down then touch-up at the given logical coordinates over the device control socket. */
+  async tap(x: number, y: number): Promise<void> {
+    const { ioSocket, resolutionWidth, resolutionHeight, currentOrientation } = this.requireSession();
+    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
+    const [cw, ch] = orientation === 1 ? [resolutionHeight, resolutionWidth] : [resolutionWidth, resolutionHeight];
+    ioSocket.sendTouch('d', [{ x, y, index: 0 }], cw, ch, orientation);
+    ioSocket.sendTouch('u', [{ x, y, index: 0 }], cw, ch, orientation);
+  }
+
+  /** Performs two taps at the same coordinates with a 100 ms gap between them. */
+  async doubleTap(x: number, y: number): Promise<void> {
+    await this.tap(x, y);
+    await new Promise((r) => setTimeout(r, 100));
+    await this.tap(x, y);
+  }
+
+  /** Holds a touch-down for the given duration (ms) before lifting, simulating a long press. */
+  async longPress(x: number, y: number, duration = 500): Promise<void> {
+    const { ioSocket, resolutionWidth, resolutionHeight, currentOrientation } = this.requireSession();
+    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
+    const [cw, ch] = orientation === 1 ? [resolutionHeight, resolutionWidth] : [resolutionWidth, resolutionHeight];
+    ioSocket.sendTouch('d', [{ x, y, index: 0 }], cw, ch, orientation);
+    await new Promise((r) => setTimeout(r, duration));
+    ioSocket.sendTouch('u', [{ x, y, index: 0 }], cw, ch, orientation);
+  }
+
+  /** Types text via socket key events for ASCII; falls back to adb `input text` for non-ASCII on Android, or character-by-character on iOS. */
+  async typeText(text: string): Promise<void> {
+    const session = this.requireSession();
+    const ascii = /^[\x00-\x7F]*$/.test(text);
+    if (ascii) {
+      for (const char of text) {
+        session.ioSocket.sendKey(char === ' ' ? 'Space' : char);
+      }
+    } else if (session.platform === 'android') {
+      const rest = this.makeRest();
+      const shellText = text.replace(/'/g, '\'\\\'\'');
+      await rest.executeShellCommand(session.sauceSessionId, `input text '${shellText}'`);
+    } else {
+      // iOS non-ASCII fallback: type character by character via socket; non-ASCII chars may not work
+      for (const char of text) {
+        session.ioSocket.sendKey(char);
+      }
+    }
+  }
+
+  /** Sends each key name sequentially through the device control socket. */
+  async pressKeys(keys: string[]): Promise<void> {
+    const { ioSocket } = this.requireSession();
+    for (const key of keys) {
+      ioSocket.sendKey(key);
+    }
+  }
+
+  /** Selects all text and deletes it using Ctrl+A and Backspace key events. */
+  async clearText(): Promise<void> {
+    const { ioSocket } = this.requireSession();
+    ioSocket.sendKey('a');
+    ioSocket.sendKey('Backspace');
+  }
+
+  /** Interpolates a swipe in the given direction as a series of touch-move events spread across the specified duration. */
+  async swipe(direction: SwipeDirection, opts?: SwipeOptions): Promise<void> {
+    const session = this.requireSession();
+    const { resolutionWidth: w, resolutionHeight: h, currentOrientation, ioSocket } = session;
+    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
+    const [cw, ch] = orientation === 1 ? [h, w] : [w, h];
+
+    const centerX = cw / 2;
+    const centerY = ch / 2;
+    const startX = opts?.startX ?? centerX;
+    const startY = opts?.startY ?? centerY;
+
+    const isHorizontal = direction === 'left' || direction === 'right';
+    const defaultDistance = (isHorizontal ? cw : ch) * 0.5;
+    const distance = opts?.distance ?? defaultDistance;
+
+    let endX = startX;
+    let endY = startY;
+    switch (direction) {
+      case 'up':    endY = startY - distance; break;
+      case 'down':  endY = startY + distance; break;
+      case 'left':  endX = startX - distance; break;
+      case 'right': endX = startX + distance; break;
+    }
+
+    const steps = 10;
+    const duration = opts?.duration ?? 300;
+    const stepDelay = Math.round(duration / steps);
+
+    ioSocket.sendTouch('d', [{ x: startX, y: startY, index: 0 }], cw, ch, orientation);
+    for (let i = 1; i <= steps; i++) {
+      const t = i / steps;
+      const mx = startX + (endX - startX) * t;
+      const my = startY + (endY - startY) * t;
+      await new Promise((r) => setTimeout(r, stepDelay));
+      ioSocket.sendTouch('m', [{ x: mx, y: my, index: 0 }], cw, ch, orientation);
+    }
+    ioSocket.sendTouch('u', [{ x: endX, y: endY, index: 0 }], cw, ch, orientation);
+  }
+
+  /** Replays a multi-pointer gesture by dispatching touch events for each pointer at their recorded timestamps. */
+  async gesture(gestures: GestureSequence): Promise<void> {
+    const session = this.requireSession();
+    const { resolutionWidth: w, resolutionHeight: h, currentOrientation, ioSocket } = session;
+    const orientation = currentOrientation === 'LANDSCAPE' ? 1 : 0;
+    const [cw, ch] = orientation === 1 ? [h, w] : [w, h];
+    const pointers = gestures.pointers;
+
+    // Collect all unique timestamps, sorted
+    const timestamps = Array.from(
+      new Set(pointers.flatMap((pts) => pts.map((p) => p.time ?? 0))),
+    ).sort((a, b) => a - b);
+
+    let prevTime = 0;
+    for (const time of timestamps) {
+      if (time > prevTime) {
+        await new Promise((r) => setTimeout(r, time - prevTime));
+      }
+      prevTime = time;
+
+      const points = pointers
+        .map((ptr, index) => {
+          const pt = ptr.find((p) => (p.time ?? 0) === time);
+          return pt ? { x: pt.x, y: pt.y, index } : null;
+        })
+        .filter((p): p is NonNullable<typeof p> => p !== null);
+
+      if (points.length > 0) {
+        const isFirst = time === timestamps[0];
+        const isLast = time === timestamps[timestamps.length - 1];
+        const action = isFirst ? 'd' : isLast ? 'u' : 'm';
+        ioSocket.sendTouch(action, points, cw, ch, orientation);
+      }
+    }
+  }
+
+  /** Presses a hardware button — via socket for HOME/BACK, adb keyevent for Android-only keys, and WDA for iOS-specific buttons. */
+  async pressButton(button: HardwareButton): Promise<void> {
+    const session = this.requireSession();
+
+    const socketKey = BUTTON_KEY[button];
+    if (socketKey) {
+      session.ioSocket.sendKey(socketKey);
+      return;
+    }
+
+    if (session.platform === 'android') {
+      const keyEvent = BUTTON_KEYEVENT[button];
+      if (keyEvent !== undefined) {
+        const rest = this.makeRest();
+        await rest.executeShellCommand(session.sauceSessionId, `input keyevent ${keyEvent}`);
+        return;
+      }
+      throw new Error(`Unsupported hardware button on Android: ${button}`);
+    }
+
+    // iOS: try socket first, fall back to WDA
+    const wdaName = BUTTON_WDA[button];
+    const wda = this.requireWda(session);
+    try {
+      session.ioSocket.sendKey(button);
+    } catch {
+      if (wdaName) {
+        await wda.pressButton(wdaName);
+        return;
+      }
+      throw new Error(`Unsupported hardware button on iOS: ${button}`);
+    }
+  }
+
+  // ─── Screen ──────────────────────────────────────────────────────────────────
+
+  /** Captures the current screen via the Sauce Labs REST API and returns the raw PNG bytes. */
+  async screenshot(_opts?: ScreenshotOptions): Promise<Buffer> {
+    const { sauceSessionId } = this.requireSession();
+    const rest = this.makeRest();
+    return rest.takeScreenshot(sauceSessionId);
+  }
+
+  /** Returns logical screen dimensions in points, accounting for pixel density and swapping width/height when in landscape. */
+  async getScreenSize(): Promise<ScreenSize> {
+    const { resolutionWidth, resolutionHeight, pixelsPerPoint, currentOrientation } = this.requireSession();
+    const scale = pixelsPerPoint || 1;
+    if (currentOrientation === 'LANDSCAPE') {
+      return { width: resolutionHeight / scale, height: resolutionWidth / scale, scale };
+    }
+    return { width: resolutionWidth / scale, height: resolutionHeight / scale, scale };
+  }
+
+  /** Returns the current device orientation, kept up-to-date by events received on the companion socket. */
+  async getOrientation(): Promise<Orientation> {
+    return sauceOrientationToProtocol(this.requireSession().currentOrientation);
+  }
+
+  /** Requests an orientation change via the REST API; the actual change is confirmed asynchronously through the companion socket. */
+  async setOrientation(orientation: Orientation): Promise<void> {
+    const { sauceSessionId } = this.requireSession();
+    const rest = this.makeRest();
+    await rest.applySettings(sauceSessionId, {
+      orientation: protocolOrientationToSauce(orientation),
+    });
+    // currentOrientation is updated asynchronously via companion socket
+  }
+
+  // ─── Apps ────────────────────────────────────────────────────────────────────
+
+  /** Launches an app; on Android re-installs with launchAfterInstall for reliability when a storage ref is available. */
+  async launchApp(bundleId: string, opts?: LaunchOptions): Promise<void> {
+    const { sauceSessionId, platform } = this.requireSession();
+    const rest = this.makeRest();
+    if (platform === 'android') {
+      // The launchApp REST endpoint does not reliably bring the app to the
+      // foreground. Re-installing with launchAfterInstall:true is the reliable
+      // path. If no previous install ref is available, fall back to the REST
+      // launchApp call.
+      const storageRef = this.lastInstalledStorageRef;
+      if (storageRef) {
+        const result = await rest.installApp(sauceSessionId, storageRef, { launchAfterInstall: true });
+        const installationId = result.installationId;
+        if (installationId) {
+          const deadline = Date.now() + 120_000;
+          while (Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, 3_000));
+            const { appInstallations } = await rest.listAppInstallations(sauceSessionId);
+            const entry = appInstallations.find((a) => a.installationId === installationId);
+            if (!entry) continue;
+            debug('launchApp install+launch %s status=%s', installationId, entry.status);
+            if (entry.status === 'FINISHED') break;
+            if (entry.status === 'ERROR') throw new Error(`App launch via install failed for ${storageRef}`);
+          }
+        }
+      } else {
+        const activityName = opts?.activity ?? `${bundleId}.MainActivity`;
+        await rest.launchApp(sauceSessionId, { packageName: bundleId, activityName });
+      }
+    } else {
+      await rest.launchApp(sauceSessionId, { bundleId });
+    }
+  }
+
+  /** Force-stops an app via adb on Android, or terminates it through WDA on iOS. */
+  async terminateApp(bundleId: string): Promise<void> {
+    const session = this.requireSession();
+    const rest = this.makeRest();
+    if (session.platform === 'android') {
+      await rest.executeShellCommand(session.sauceSessionId, `am force-stop ${bundleId}`);
+    } else {
+      const wda = this.requireWda(session);
+      await wda.terminateApp(bundleId);
+    }
+  }
+
+  /** Uploads the app to Sauce Storage if not already there, then installs it on the device and polls until the installation completes. */
+  async installApp(filePathOrStorageRef: string): Promise<void> {
+    const { sauceSessionId } = this.requireSession();
+    const rest = this.makeRest();
+    const storageRef = filePathOrStorageRef.startsWith('storage:')
+      ? filePathOrStorageRef
+      : await rest.uploadToStorage(filePathOrStorageRef);
+    this.lastInstalledStorageRef = storageRef;
+    const result = await rest.installApp(sauceSessionId, storageRef);
+    const installationId = result.installationId;
+    if (!installationId) return;
+
+    // installApp is non-blocking; poll until FINISHED or ERROR.
+    const deadline = Date.now() + 120_000;
+    const pollInterval = 3_000;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, pollInterval));
+      const { appInstallations } = await rest.listAppInstallations(sauceSessionId);
+      const entry = appInstallations.find((a) => a.installationId === installationId);
+      if (!entry) continue;
+      debug('install %s status=%s', installationId, entry.status);
+      if (entry.status === 'FINISHED') return;
+      if (entry.status === 'ERROR') throw new Error(`App installation failed for ${storageRef}`);
+    }
+    throw new Error(`Timed out waiting for app installation to complete: ${storageRef}`);
+  }
+
+  /** Removes an installed app from the device using the appropriate identifier for the platform. */
+  async uninstallApp(bundleId: string): Promise<void> {
+    const { sauceSessionId, platform } = this.requireSession();
+    const rest = this.makeRest();
+    if (platform === 'android') {
+      await rest.uninstallApp(sauceSessionId, { packageName: bundleId });
+    } else {
+      await rest.uninstallApp(sauceSessionId, { bundleId });
+    }
+  }
+
+  /** Lists installed third-party apps via `pm list packages` on Android, or WDA's app list on iOS. */
+  async listApps(): Promise<AppInfo[]> {
+    const session = this.requireSession();
+    const rest = this.makeRest();
+    if (session.platform === 'android') {
+      const stdout = await rest.executeShellCommand(session.sauceSessionId, 'pm list packages -3');
+      return parsePmListPackages(stdout);
+    } else {
+      const wda = this.requireWda(session);
+      return wda.listApps();
+    }
+  }
+
+  /** Returns the currently active app — parsed from `dumpsys window` on Android, or from WDA's activeAppInfo on iOS. */
+  async getForegroundApp(): Promise<AppInfo> {
+    const session = this.requireSession();
+    const rest = this.makeRest();
+    if (session.platform === 'android') {
+      // Use full dumpsys output (no grep) to avoid empty stdout on grep exit-code != 0.
+      const stdout = await rest.executeShellCommand(session.sauceSessionId, 'dumpsys window');
+      debug('getForegroundApp window stdout length=%d', stdout.length);
+      const app = parseForegroundApp(stdout);
+      debug('getForegroundApp bundleId=%s', app.bundleId);
+      return app;
+    } else {
+      const wda = this.requireWda(session);
+      return wda.getActiveAppInfo();
+    }
+  }
+
+  // ─── Device ──────────────────────────────────────────────────────────────────
+
+  /** Fetches the device catalog and live availability status, returning devices optionally filtered by platform and state. */
+  async listDevices(opts?: ListDevicesOptions): Promise<DeviceInfo[]> {
+    const rest = this.makeRest();
+    const [descriptors, statusResp] = await Promise.all([
+      rest.listDevices(),
+      rest.listDeviceStatus(),
+    ]);
+
+    const statusMap = new Map<string, string>();
+    for (const s of statusResp.devices) {
+      statusMap.set(s.descriptor, s.state);
+    }
+
+    let devices: DeviceInfo[] = descriptors
+      .filter((d) => {
+        if (opts?.platform) {
+          const os = d.os.toLowerCase() as Platform;
+          if (os !== opts.platform) return false;
+        }
+        return true;
+      })
+      .map((d) => {
+        const rawState = statusMap.get(d.id) ?? 'AVAILABLE';
+        const state = rawState === 'IN_USE' ? 'offline' as const : 'online' as const;
+        return {
+          id: d.id,
+          name: d.name,
+          platform: (d.os.toLowerCase() === 'android' ? 'android' : 'ios') as Platform,
+          type: 'real' as const,
+          state,
+          model: d.name,
+          osVersion: d.osVersion,
+        };
+      });
+
+    if (opts?.state) {
+      devices = devices.filter((d) => d.state === opts.state);
+    }
+
+    return devices;
+  }
+
+  /** Opens the given URL in the device's default browser via the Sauce Labs REST API. */
+  async openUrl(url: string): Promise<void> {
+    const { sauceSessionId } = this.requireSession();
+    const rest = this.makeRest();
+    await rest.openUrl(sauceSessionId, url);
+  }
+
+  // ─── Recording ───────────────────────────────────────────────────────────────
+
+  /** Starts buffering MJPEG frames received from the device control socket for later encoding. */
+  async startRecording(opts: RecordingOptions): Promise<void> {
+    const { ioSocket } = this.requireSession();
+    this.recordingOptions = opts;
+    ioSocket.startFrameCapture();
+  }
+
+  /** Stops frame capture and encodes the buffered MJPEG frames into an MP4 file at the path specified in `startRecording`. */
+  async stopRecording(): Promise<RecordingResult> {
+    const { ioSocket } = this.requireSession();
+    const opts = this.recordingOptions;
+    if (!opts) throw new Error('stopRecording called without a prior startRecording');
+    this.recordingOptions = null;
+
+    const frames = ioSocket.stopFrameCapture();
+    const endTs = ioSocket.getCaptureEndTs();
+    if (frames.length === 0) {
+      return { output: opts.output, duration: 0 };
+    }
+
+    await encodeFramesToMp4(frames, endTs, opts.output);
+    const duration = (endTs - frames[0].ts) / 1000;
+
+    return { output: opts.output, duration };
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+  /** Asserts an active session exists and returns it, throwing if `connect()` has not been called. */
+  private requireSession(): ActiveSession {
+    if (!this.session) throw new Error('No active session. Call connect() first.');
+    return this.session;
+  }
+
+  /** Creates a REST client configured with the current credentials and region. */
+  private makeRest(): RestClient {
+    return new RestClient(
+      this.username,
+      this.accessKey,
+      this.options.region ?? 'us-west-1',
+    );
+  }
+
+  /** Returns the WDA client for the session, throwing if it is not available (non-iOS session). */
+  private requireWda(session: ActiveSession): WdaClient {
+    if (!session.wdaClient) throw new Error('WDA client is only available on iOS');
+    return session.wdaClient;
+  }
+}
+
+// ─── uiautomator XML parser ──────────────────────────────────────────────────
+
+function parseUiautomatorXml(xml: string): ViewNode[] {
+  const root: ViewNode[] = [];
+  const stack: ViewNode[][] = [root];
+  const tagRe = /<(\/?)(\w[\w.]*)\s*([^>]*)>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRe.exec(xml)) !== null) {
+    const [, closing, tag, attrsRaw] = match;
+
+    if (closing) {
+      if (stack.length > 1) stack.pop();
+      continue;
+    }
+
+    const attrs = parseAttrsFromXml(attrsRaw);
+    const isSelfClosing = attrsRaw.trimEnd().endsWith('/');
+
+    // bounds="[x1,y1][x2,y2]"
+    let bx = 0, by = 0, bw = 0, bh = 0;
+    // noinspection RegExpRedundantEscape
+    const boundsMatch = (attrs['bounds'] ?? '').match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
+    if (boundsMatch) {
+      bx = Number(boundsMatch[1]);
+      by = Number(boundsMatch[2]);
+      bw = Number(boundsMatch[3]) - bx;
+      bh = Number(boundsMatch[4]) - by;
+    }
+
+    const node: ViewNode = {
+      type: attrs['class'] ?? tag,
+      label: attrs['content-desc'] || undefined,
+      identifier: attrs['resource-id'] || undefined,
+      resourceId: attrs['resource-id'] || undefined,
+      text: attrs['text'] || undefined,
+      isVisible: true,
+      isEnabled: attrs['enabled'] !== 'false',
+      isSelected: attrs['selected'] === 'true',
+      isFocused: attrs['focused'] === 'true',
+      isChecked: attrs['checked'] === 'true',
+      bounds: { x: bx, y: by, width: bw, height: bh },
+      children: [],
+      raw: { ...attrs },
+    };
+
+    stack[stack.length - 1].push(node);
+    if (!isSelfClosing) {
+      stack.push(node.children);
+    }
+  }
+
+  return root;
+}
+
+function parseAttrsFromXml(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const re = /([\w-]+)="([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) !== null) {
+    attrs[m[1]] = m[2];
+  }
+  return attrs;
+}
+
+// ─── ffmpeg encoder ──────────────────────────────────────────────────────────
+
+function resolveFFmpegPath(): string {
+  try {
+    // Prefer Playwright's bundled ffmpeg over the system one.
+     
+    const { registry } = require('playwright-core/lib/server/registry/index.js');
+    return registry.findExecutable('ffmpeg').executablePath('javascript') as string;
+  } catch {
+    return 'ffmpeg';
+  }
+}
+
+const FFMPEG_PATH = resolveFFmpegPath();
+
+function encodeFramesToMp4(
+  frames: { frame: Buffer; ts: number }[],
+  endTs: number,
+  output: string,
+): Promise<void> {
+  // Compute the real recording duration and derive the input framerate so that
+  // the video length matches wall-clock time regardless of how many frames
+  // arrived (screen may be static for long stretches between changes).
+  const durationSec = Math.max((endTs - frames[0].ts) / 1000, 0.1);
+  const inputFps = `${frames.length}/${durationSec.toFixed(3)}`;
+
+  return new Promise<void>((resolve, reject) => {
+    const ffmpeg = spawn(FFMPEG_PATH, [
+      '-y',
+      '-f', 'image2pipe',
+      '-vcodec', 'mjpeg',
+      '-r', inputFps,
+      '-i', 'pipe:0',
+      '-vcodec', 'libx264',
+      '-pix_fmt', 'yuv420p',
+      output,
+    ], { stdio: ['pipe', 'ignore', 'ignore'] });
+
+    ffmpeg.on('error', (err) => reject(new Error(`ffmpeg spawn failed: ${err.message}`)));
+    ffmpeg.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`ffmpeg exited with code ${code}`));
+    });
+
+    const stdin = ffmpeg.stdin!;
+    for (const { frame } of frames) {
+      stdin.write(frame);
+    }
+    stdin.end();
+  });
+}

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -494,11 +494,10 @@ export class SauceLabsDriver implements MobilewrightDriver {
     }
   }
 
-  /** Selects all text and deletes it using a select-all chord (Cmd+A on iOS, Ctrl+A on Android) and Backspace. */
+  /** Selects all text and deletes it using Ctrl+A and Backspace key events. */
   async clearText(): Promise<void> {
-    const { ioSocket, platform } = this.requireSession();
-    const selectAll = platform === 'ios' ? 'cmd+a' : 'ctrl+a';
-    ioSocket.sendKey(selectAll);
+    const { ioSocket } = this.requireSession();
+    ioSocket.sendKey('a');
     ioSocket.sendKey('Backspace');
   }
 

--- a/packages/driver-saucelabs/src/driver.ts
+++ b/packages/driver-saucelabs/src/driver.ts
@@ -32,6 +32,9 @@ const DEFAULT_WDA_URL =
   process.env['SAUCE_IOS_WDA_URL'] ??
   'https://github.com/appium/WebDriverAgent/releases/download/v15.0.0/WebDriverAgentRunner-Runner.zip';
 
+/** Prints the Sauce Labs live-view URL to the console on session creation when set to '1'. */
+const SHOW_LIVE_VIEW = process.env['SAUCE_LIVE_VIEW'] === '1';
+
 export interface SauceLabsDriverOptions {
   /** Falls back to SAUCE_USERNAME env var when omitted. */
   username?: string;
@@ -290,6 +293,10 @@ export class SauceLabsDriver implements MobilewrightDriver {
     // waitForActiveSession() guarantees links are present before returning.
     const links = sauceSession.links!;
 
+    if (SHOW_LIVE_VIEW && links.liveViewUrl) {
+      console.log(`📱 Sauce Labs live view (${descriptor}): 🔗 ${links.liveViewUrl}`);
+    }
+
     // Fetch device descriptor for screen metrics
     let resolutionWidth = 1080;
     let resolutionHeight = 1920;
@@ -312,7 +319,14 @@ export class SauceLabsDriver implements MobilewrightDriver {
     const ioSocket = new DeviceControlSocket(links.ioWebsocketUrl, this.username, this.accessKey);
     const companionSocket = new CompanionSocket(links.eventsWebsocketUrl, this.username, this.accessKey);
 
-    await Promise.all([ioSocket.connect(), companionSocket.connect()]);
+    try {
+      await Promise.all([ioSocket.connect(), companionSocket.connect()]);
+    } catch (err) {
+      // Clean up any successfully connected sockets before propagating the error
+      await ioSocket.disconnect().catch(() => {});
+      await companionSocket.disconnect().catch(() => {});
+      throw err;
+    }
 
     let wdaStorageRef: string | undefined;
     if (platform === 'ios') {
@@ -473,10 +487,11 @@ export class SauceLabsDriver implements MobilewrightDriver {
     }
   }
 
-  /** Selects all text and deletes it using Ctrl+A and Backspace key events. */
+  /** Selects all text and deletes it using a select-all chord (Cmd+A on iOS, Ctrl+A on Android) and Backspace. */
   async clearText(): Promise<void> {
-    const { ioSocket } = this.requireSession();
-    ioSocket.sendKey('a');
+    const { ioSocket, platform } = this.requireSession();
+    const selectAll = platform === 'ios' ? 'cmd+a' : 'ctrl+a';
+    ioSocket.sendKey(selectAll);
     ioSocket.sendKey('Backspace');
   }
 
@@ -574,18 +589,14 @@ export class SauceLabsDriver implements MobilewrightDriver {
       throw new Error(`Unsupported hardware button on Android: ${button}`);
     }
 
-    // iOS: try socket first, fall back to WDA
+    // iOS: buttons not in the socket key mapping (checked above) go to WDA.
     const wdaName = BUTTON_WDA[button];
-    const wda = this.requireWda(session);
-    try {
-      session.ioSocket.sendKey(button);
-    } catch {
-      if (wdaName) {
-        await wda.pressButton(wdaName);
-        return;
-      }
-      throw new Error(`Unsupported hardware button on iOS: ${button}`);
+    if (wdaName) {
+      const wda = this.requireWda(session);
+      await wda.pressButton(wdaName);
+      return;
     }
+    throw new Error(`Unsupported hardware button on iOS: ${button}`);
   }
 
   // ─── Screen ──────────────────────────────────────────────────────────────────
@@ -639,14 +650,21 @@ export class SauceLabsDriver implements MobilewrightDriver {
         const installationId = result.installationId;
         if (installationId) {
           const deadline = Date.now() + 120_000;
+          let finished = false;
           while (Date.now() < deadline) {
             await new Promise((r) => setTimeout(r, 3_000));
             const { appInstallations } = await rest.listAppInstallations(sauceSessionId);
             const entry = appInstallations.find((a) => a.installationId === installationId);
             if (!entry) continue;
             debug('launchApp install+launch %s status=%s', installationId, entry.status);
-            if (entry.status === 'FINISHED') break;
+            if (entry.status === 'FINISHED') {
+              finished = true;
+              break;
+            }
             if (entry.status === 'ERROR') throw new Error(`App launch via install failed for ${storageRef}: ${JSON.stringify(entry)}`);
+          }
+          if (!finished) {
+            throw new Error(`Timed out waiting for app launch to complete: ${storageRef}`);
           }
         }
       } else {

--- a/packages/driver-saucelabs/src/index.ts
+++ b/packages/driver-saucelabs/src/index.ts
@@ -1,0 +1,1 @@
+export { SauceLabsDriver, type SauceLabsDriverOptions } from './driver.js';

--- a/packages/driver-saucelabs/src/integration.test.ts
+++ b/packages/driver-saucelabs/src/integration.test.ts
@@ -14,12 +14,13 @@ import { SauceLabsDriver } from './driver.js';
 import type { Region } from './rest-client.js';
 
 const INTEGRATION = process.env['SAUCE_INTEGRATION'] === '1';
+const HAS_CREDENTIALS = Boolean(process.env['SAUCE_USERNAME'] && process.env['SAUCE_ACCESS_KEY']);
 const PLATFORM = (process.env['SAUCE_PLATFORM'] ?? 'ios') as Platform;
 const REGION = (process.env['SAUCE_REGION'] ?? 'us-west-1') as Region;
 const IOS_WDA_STORAGE_REF = process.env['SAUCE_IOS_WDA_STORAGE_REF'];
 
 test.describe('SauceLabsDriver integration', () => {
-  test.skip(!INTEGRATION, 'Requires SAUCE_INTEGRATION=1, SAUCE_USERNAME, and SAUCE_ACCESS_KEY');
+  test.skip(!INTEGRATION || !HAS_CREDENTIALS, 'Requires SAUCE_INTEGRATION=1, SAUCE_USERNAME, and SAUCE_ACCESS_KEY');
   test.setTimeout(120_000);
 
   test('connects and returns a session with the correct platform', async () => {

--- a/packages/driver-saucelabs/src/integration.test.ts
+++ b/packages/driver-saucelabs/src/integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Integration test that connects to a real Sauce Labs device.
+ *
+ * Requires:
+ *   - SAUCE_USERNAME environment variable
+ *   - SAUCE_ACCESS_KEY environment variable
+ *   - SAUCE_INTEGRATION=1 environment variable
+ *   - SAUCE_PLATFORM=ios|android (default: ios)
+ *   - SAUCE_REGION=us-west-1|eu-central-1|us-east-4 (default: us-west-1)
+ */
+import { test, expect } from '@playwright/test';
+import type { Platform } from '@mobilewright/protocol';
+import { SauceLabsDriver } from './driver.js';
+import type { Region } from './rest-client.js';
+
+const INTEGRATION = process.env['SAUCE_INTEGRATION'] === '1';
+const PLATFORM = (process.env['SAUCE_PLATFORM'] ?? 'ios') as Platform;
+const REGION = (process.env['SAUCE_REGION'] ?? 'us-west-1') as Region;
+const IOS_WDA_STORAGE_REF = process.env['SAUCE_IOS_WDA_STORAGE_REF'];
+
+test.describe('SauceLabsDriver integration', () => {
+  test.skip(!INTEGRATION, 'Requires SAUCE_INTEGRATION=1, SAUCE_USERNAME, and SAUCE_ACCESS_KEY');
+  test.setTimeout(120_000);
+
+  test('connects and returns a session with the correct platform', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+
+    const session = await driver.connect({ platform: PLATFORM });
+    try {
+      expect(session.platform).toBe(PLATFORM);
+      expect(session.deviceId).toBeTruthy();
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('takes a screenshot and returns a non-empty Buffer', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      const screenshot = await driver.screenshot();
+      expect(screenshot).toBeInstanceOf(Buffer);
+      expect(screenshot.length).toBeGreaterThan(100);
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('getScreenSize returns positive dimensions', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      const size = await driver.getScreenSize();
+      expect(size.width).toBeGreaterThan(0);
+      expect(size.height).toBeGreaterThan(0);
+      expect(size.scale).toBeGreaterThanOrEqual(1);
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('getOrientation returns portrait or landscape', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      const orientation = await driver.getOrientation();
+      expect(orientation).toMatch(/^(portrait|landscape)$/);
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('getViewHierarchy returns a non-empty node tree', async () => {
+    test.setTimeout(180_000);
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      const hierarchy = await driver.getViewHierarchy();
+      expect(Array.isArray(hierarchy)).toBe(true);
+      expect(hierarchy.length).toBeGreaterThan(0);
+      expect(hierarchy[0].type).toBeTruthy();
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('listDevices returns at least one device', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      const devices = await driver.listDevices();
+      expect(devices.length).toBeGreaterThan(0);
+      expect(devices[0].id).toBeTruthy();
+      expect(devices[0].platform).toMatch(/^(ios|android)$/);
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('tap does not throw', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      const size = await driver.getScreenSize();
+      await expect(driver.tap(size.width / 2, size.height / 2)).resolves.toBeUndefined();
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  test('pressButton HOME does not throw', async () => {
+    const driver = new SauceLabsDriver({
+      region: REGION,
+      ...(IOS_WDA_STORAGE_REF ? { iosWdaStorageRef: IOS_WDA_STORAGE_REF } : {}),
+    });
+    await driver.connect({ platform: PLATFORM });
+
+    try {
+      await expect(driver.pressButton('HOME')).resolves.toBeUndefined();
+    } finally {
+      await driver.disconnect();
+    }
+  });
+});

--- a/packages/driver-saucelabs/src/rest-client.test.ts
+++ b/packages/driver-saucelabs/src/rest-client.test.ts
@@ -1,0 +1,438 @@
+import { test, expect } from '@playwright/test';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RestClient } from './rest-client.js';
+
+// ─── Mock fetch helpers ──────────────────────────────────────────────────────
+
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+};
+
+function makeMockFetch(responses: Record<string, { status: number; body: unknown }>) {
+  const calls: FetchCall[] = [];
+
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    let parsedBody: unknown = init?.body;
+    if (typeof parsedBody === 'string') {
+      try { parsedBody = JSON.parse(parsedBody); } catch { /* leave as string */ }
+    }
+    calls.push({ url, method, headers, body: parsedBody });
+
+    // match the longest suffix key
+    const key = Object.keys(responses).find((k) => url.includes(k)) ?? '__default';
+    const resp = responses[key] ?? { status: 200, body: {} };
+    const responseBody = resp.body instanceof Uint8Array
+      ? resp.body
+      : JSON.stringify(resp.body);
+    return new Response(responseBody as string, { status: resp.status });
+  };
+
+  return { mockFetch: mockFetch as typeof globalThis.fetch, calls };
+}
+
+const BASE = 'https://api.us-west-1.saucelabs.com/rdc/v2';
+const STORAGE_BASE = 'https://api.us-west-1.saucelabs.com/v1/storage/upload';
+
+function client(overrides?: Record<string, { status: number; body: unknown }>) {
+  const { mockFetch, calls } = makeMockFetch(overrides ?? { '': { status: 200, body: {} } });
+  const rest = new RestClient('alice', 'secret-key', 'us-west-1', mockFetch);
+  return { rest, calls };
+}
+
+// ─── Auth header ─────────────────────────────────────────────────────────────
+
+test('includes Basic auth header with base64(username:accessKey)', async () => {
+  const { rest, calls } = client({ '/sessions': { status: 200, body: { id: 's1', state: 'CREATING' } } });
+  await rest.createSession({ device: { os: 'ANDROID' } });
+
+  const expectedToken = Buffer.from('alice:secret-key').toString('base64');
+  expect(calls[0].headers['Authorization']).toBe(`Basic ${expectedToken}`);
+});
+
+// ─── Region → URL ────────────────────────────────────────────────────────────
+
+test('uses eu-central-1 base URL when region is eu-central-1', async () => {
+  const { mockFetch, calls } = makeMockFetch({ '': { status: 200, body: [] } });
+  const rest = new RestClient('u', 'k', 'eu-central-1', mockFetch);
+  await rest.listDevices();
+  expect(calls[0].url).toMatch(/api\.eu-central-1\.saucelabs\.com/);
+});
+
+test('uses us-east-4 base URL when region is us-east-4', async () => {
+  const { mockFetch, calls } = makeMockFetch({ '': { status: 200, body: [] } });
+  const rest = new RestClient('u', 'k', 'us-east-4', mockFetch);
+  await rest.listDevices();
+  expect(calls[0].url).toMatch(/api\.us-east-4\.saucelabs\.com/);
+});
+
+// ─── Session endpoints ───────────────────────────────────────────────────────
+
+test('createSession sends POST /sessions with device os', async () => {
+  const { rest, calls } = client({ '/sessions': { status: 200, body: { id: 's1', state: 'CREATING' } } });
+  await rest.createSession({ device: { os: 'ANDROID' } });
+
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].url).toBe(`${BASE}/sessions`);
+  expect((calls[0].body as Record<string, unknown>)['device']).toMatchObject({ os: 'ANDROID' });
+});
+
+test('createSession includes sessionDuration when provided', async () => {
+  const { rest, calls } = client({ '/sessions': { status: 200, body: { id: 's1', state: 'CREATING' } } });
+  await rest.createSession({
+    device: { os: 'IOS' },
+    configuration: { sessionDuration: 'PT1H' },
+  });
+
+  const body = calls[0].body as Record<string, unknown>;
+  expect((body['configuration'] as Record<string, unknown>)['sessionDuration']).toBe('PT1H');
+});
+
+test('getSession sends GET /sessions/{id}', async () => {
+  const { rest, calls } = client({ '/sessions/abc': { status: 200, body: { id: 'abc', state: 'ACTIVE' } } });
+  const session = await rest.getSession('abc');
+
+  expect(calls[0].method).toBe('GET');
+  expect(calls[0].url).toBe(`${BASE}/sessions/abc`);
+  expect(session.state).toBe('ACTIVE');
+});
+
+test('deleteSession sends DELETE /sessions/{id}', async () => {
+  const { rest, calls } = client({ '/sessions/abc': { status: 200, body: {} } });
+  await rest.deleteSession('abc');
+
+  expect(calls[0].method).toBe('DELETE');
+  expect(calls[0].url).toBe(`${BASE}/sessions/abc`);
+});
+
+test('deleteSession does not throw on 404', async () => {
+  const { rest } = client({ '/sessions/abc': { status: 404, body: null } });
+  await expect(rest.deleteSession('abc')).resolves.toBeUndefined();
+});
+
+// ─── Device endpoints ────────────────────────────────────────────────────────
+
+test('listDevices sends GET /devices', async () => {
+  const { rest, calls } = client({ '/devices': { status: 200, body: [] } });
+  await rest.listDevices();
+
+  expect(calls[0].method).toBe('GET');
+  expect(calls[0].url).toBe(`${BASE}/devices`);
+});
+
+test('listDeviceStatus sends GET /devices/status', async () => {
+  const { rest, calls } = client({ '/devices/status': { status: 200, body: { devices: [] } } });
+  await rest.listDeviceStatus();
+
+  expect(calls[0].method).toBe('GET');
+  expect(calls[0].url).toBe(`${BASE}/devices/status`);
+});
+
+// ─── Device interaction endpoints ────────────────────────────────────────────
+
+test('executeShellCommand sends adbShellCommand in body and returns stdout', async () => {
+  const { rest, calls } = client({
+    'executeShellCommand': { status: 200, body: { stdout: 'package:com.example.app\n' } },
+  });
+  const result = await rest.executeShellCommand('sess1', 'pm list packages -3');
+
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].url).toContain('/sessions/sess1/device/executeShellCommand');
+  expect((calls[0].body as Record<string, unknown>)['adbShellCommand']).toBe('pm list packages -3');
+  expect(result).toBe('package:com.example.app\n');
+});
+
+test('applySettings sends orientation in body', async () => {
+  const { rest, calls } = client({ 'applySettings': { status: 200, body: {} } });
+  await rest.applySettings('sess1', { orientation: 'LANDSCAPE' });
+
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].url).toContain('/sessions/sess1/device/applySettings');
+  expect((calls[0].body as Record<string, unknown>)['orientation']).toBe('LANDSCAPE');
+});
+
+test('applySettings sends animations in body', async () => {
+  const { rest, calls } = client({ 'applySettings': { status: 200, body: {} } });
+  await rest.applySettings('sess1', { animations: false });
+
+  expect((calls[0].body as Record<string, unknown>)['animations']).toBe(false);
+});
+
+test('launchApp sends bundleId for iOS', async () => {
+  const { rest, calls } = client({ 'launchApp': { status: 200, body: {} } });
+  await rest.launchApp('sess1', { bundleId: 'com.example.App' });
+
+  expect(calls[0].url).toContain('/sessions/sess1/device/launchApp');
+  expect((calls[0].body as Record<string, unknown>)['bundleId']).toBe('com.example.App');
+});
+
+test('launchApp sends packageName and activityName for Android', async () => {
+  const { rest, calls } = client({ 'launchApp': { status: 200, body: {} } });
+  await rest.launchApp('sess1', { packageName: 'com.example.app', activityName: '.MainActivity' });
+
+  const body = calls[0].body as Record<string, unknown>;
+  expect(body['packageName']).toBe('com.example.app');
+  expect(body['activityName']).toBe('.MainActivity');
+});
+
+test('installApp sends storage ref and enableInstrumentation', async () => {
+  const { rest, calls } = client({ 'installApp': { status: 200, body: { status: 'OK' } } });
+  await rest.installApp('sess1', 'storage:uuid-123');
+
+  const body = calls[0].body as Record<string, unknown>;
+  expect(body['app']).toBe('storage:uuid-123');
+  expect(body['enableInstrumentation']).toBe(true);
+});
+
+test('uninstallApp sends bundleId', async () => {
+  const { rest, calls } = client({ 'uninstallApp': { status: 200, body: {} } });
+  await rest.uninstallApp('sess1', { bundleId: 'com.example.App' });
+
+  expect((calls[0].body as Record<string, unknown>)['bundleId']).toBe('com.example.App');
+});
+
+test('uninstallApp sends packageName for Android', async () => {
+  const { rest, calls } = client({ 'uninstallApp': { status: 200, body: {} } });
+  await rest.uninstallApp('sess1', { packageName: 'com.example.app' });
+
+  expect((calls[0].body as Record<string, unknown>)['packageName']).toBe('com.example.app');
+});
+
+test('openUrl sends url in body', async () => {
+  const { rest, calls } = client({ 'openUrl': { status: 200, body: {} } });
+  await rest.openUrl('sess1', 'https://example.com');
+
+  expect((calls[0].body as Record<string, unknown>)['url']).toBe('https://example.com');
+});
+
+test('takeScreenshot returns Buffer from binary response', async () => {
+  const pngBytes = new Uint8Array([137, 80, 78, 71]);
+  const { rest } = client({ 'takeScreenshot': { status: 200, body: pngBytes } });
+  const result = await rest.takeScreenshot('sess1');
+
+  expect(result).toBeInstanceOf(Buffer);
+  expect(result[0]).toBe(137);
+});
+
+// ─── Storage upload ───────────────────────────────────────────────────────────
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'mw-saucelabs-rest-test-'));
+
+test.afterAll(() => {
+  rmSync(tmpDir, { recursive: true });
+});
+
+test('uploadToStorage sends FormData to storage URL and returns storage:uuid', async () => {
+  const filePath = join(tmpDir, 'app.apk');
+  writeFileSync(filePath, 'fake apk content');
+
+  const { mockFetch, calls } = makeMockFetch({
+    '': { status: 200, body: { item: { id: 'uuid-abc-123' } } },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  const ref = await rest.uploadToStorage(filePath);
+
+  expect(ref).toBe('storage:uuid-abc-123');
+  expect(calls[0].url).toBe(STORAGE_BASE);
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].body).toBeInstanceOf(FormData);
+});
+
+test('uploadToStorage throws when response is missing item.id', async () => {
+  const filePath = join(tmpDir, 'bad.apk');
+  writeFileSync(filePath, 'content');
+
+  const { mockFetch } = makeMockFetch({ '': { status: 200, body: {} } });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  await expect(rest.uploadToStorage(filePath)).rejects.toThrow('missing item.id');
+});
+
+// ─── WDA launch ──────────────────────────────────────────────────────────────
+
+test('launchWebDriverAgent sends bundleId and no app when only bundleId is given', async () => {
+  const { rest, calls } = client({ 'launchWebDriverAgent': { status: 200, body: {} } });
+  await rest.launchWebDriverAgent('sess1', { bundleId: 'com.example.WDA' });
+
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].url).toContain('/sessions/sess1/device/launchWebDriverAgent');
+  const body = calls[0].body as Record<string, unknown>;
+  expect(body['bundleId']).toBe('com.example.WDA');
+  expect(body['app']).toBeUndefined();
+});
+
+test('launchWebDriverAgent includes app when a storage ref is given', async () => {
+  const { rest, calls } = client({ 'launchWebDriverAgent': { status: 200, body: {} } });
+  await rest.launchWebDriverAgent('sess1', {
+    bundleId: 'com.example.WDA',
+    app: 'storage:wda-uuid-456',
+  });
+
+  const body = calls[0].body as Record<string, unknown>;
+  expect(body['bundleId']).toBe('com.example.WDA');
+  expect(body['app']).toBe('storage:wda-uuid-456');
+});
+
+test('launchWebDriverAgent uses DEFAULT_WDA_BUNDLE_ID when none is provided', async () => {
+  const { rest, calls } = client({ 'launchWebDriverAgent': { status: 200, body: {} } });
+  await rest.launchWebDriverAgent('sess1');
+
+  const body = calls[0].body as Record<string, unknown>;
+  expect(body['bundleId']).toBe('com.facebook.WebDriverAgentRunner.xctrunner');
+});
+
+test('launchWebDriverAgent uses xctrunner bundleId when app is provided without explicit bundleId', async () => {
+  const { rest, calls } = client({ 'launchWebDriverAgent': { status: 200, body: {} } });
+  await rest.launchWebDriverAgent('sess1', { app: 'storage:wda-uuid-xyz' });
+
+  const body = calls[0].body as Record<string, unknown>;
+  expect(body['bundleId']).toBe('com.facebook.WebDriverAgentRunner.xctrunner');
+  expect(body['app']).toBe('storage:wda-uuid-xyz');
+});
+
+// ─── uploadUrlToStorage ───────────────────────────────────────────────────────
+
+test('uploadUrlToStorage downloads from URL then uploads to storage', async () => {
+  const fakeZip = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // ZIP magic bytes
+
+  const { mockFetch, calls } = makeMockFetch({
+    'github.com': { status: 200, body: fakeZip },
+    'storage/upload': { status: 200, body: { item: { id: 'wda-uuid-789' } } },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+
+  const ref = await rest.uploadUrlToStorage(
+    'https://github.com/appium/WebDriverAgent/releases/download/v15.0.0/WebDriverAgentRunner-Runner.zip',
+  );
+
+  expect(ref).toBe('storage:wda-uuid-789');
+  expect(calls[0].method).toBe('GET');
+  expect(calls[0].url).toContain('github.com');
+  expect(calls[1].url).toBe(STORAGE_BASE);
+  expect(calls[1].method).toBe('POST');
+  expect(calls[1].body).toBeInstanceOf(FormData);
+});
+
+test('uploadUrlToStorage throws when download fails', async () => {
+  const { mockFetch } = makeMockFetch({
+    'github.com': { status: 404, body: 'Not Found' },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+
+  await expect(
+    rest.uploadUrlToStorage('https://github.com/appium/WebDriverAgent/releases/download/v15.0.0/WebDriverAgentRunner-Runner.zip'),
+  ).rejects.toThrow('Failed to download');
+});
+
+// ─── findInStorage ────────────────────────────────────────────────────────────
+
+test('findInStorage returns storage ref when file is found', async () => {
+  const { mockFetch, calls } = makeMockFetch({
+    '/storage/files': { status: 200, body: { items: [{ id: 'found-uuid', name: 'v15.0.0-WebDriverAgentRunner-Runner.ipa' }] } },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  const ref = await rest.findInStorage('v15.0.0-WebDriverAgentRunner-Runner.ipa');
+
+  expect(ref).toBe('storage:found-uuid');
+  expect(calls[0].url).toContain('/storage/files');
+  expect(calls[0].url).toContain('v15.0.0-WebDriverAgentRunner-Runner.ipa');
+});
+
+test('findInStorage returns null when file is not found', async () => {
+  const { mockFetch } = makeMockFetch({
+    '/storage/files': { status: 200, body: { items: [] } },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  const ref = await rest.findInStorage('missing.ipa');
+
+  expect(ref).toBeNull();
+});
+
+test('findInStorage returns null on non-2xx response', async () => {
+  const { mockFetch } = makeMockFetch({
+    '/storage/files': { status: 500, body: {} },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  const ref = await rest.findInStorage('something.ipa');
+
+  expect(ref).toBeNull();
+});
+
+// ─── uploadWdaToStorage ───────────────────────────────────────────────────────
+
+test('uploadWdaToStorage returns existing ref without downloading when file is in storage', async () => {
+  const { mockFetch, calls } = makeMockFetch({
+    '/storage/files': { status: 200, body: { items: [{ id: 'existing-uuid', name: 'v15.0.0-WebDriverAgentRunner-Runner.ipa' }] } },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  const ref = await rest.uploadWdaToStorage(
+    'https://github.com/appium/WebDriverAgent/releases/download/v15.0.0/WebDriverAgentRunner-Runner.zip',
+  );
+
+  expect(ref).toBe('storage:filename=v15.0.0-WebDriverAgentRunner-Runner.ipa');
+  expect(calls).toHaveLength(1);
+  expect(calls[0].url).toContain('/storage/files');
+});
+
+test('uploadWdaToStorage derives versioned IPA filename from URL', async () => {
+  const fakeZip = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  const { mockFetch, calls } = makeMockFetch({
+    '/storage/files': { status: 200, body: { items: [] } },
+    'github.com': { status: 200, body: fakeZip },
+    'storage/upload': { status: 200, body: { item: { id: 'new-uuid' } } },
+  });
+  const rest = new RestClient('u', 'k', 'us-west-1', mockFetch);
+  await rest.uploadWdaToStorage(
+    'https://github.com/appium/WebDriverAgent/releases/download/v15.0.0/WebDriverAgentRunner-Runner.zip',
+  );
+
+  const uploadCall = calls.find((c) => c.url.includes('storage/upload'));
+  expect(uploadCall).toBeTruthy();
+  const formData = uploadCall!.body as FormData;
+  expect(formData).toBeInstanceOf(FormData);
+});
+
+// ─── WDA proxy ────────────────────────────────────────────────────────────────
+
+test('wdaRequest builds correct proxy URL', async () => {
+  const { rest, calls } = client({
+    '/proxy/http': { status: 200, body: { value: 'ok' } },
+  });
+  await rest.wdaRequest('sess1', 'GET', 'localhost', 8100, '/source', undefined);
+
+  expect(calls[0].url).toBe(`${BASE}/sessions/sess1/device/proxy/http/localhost/8100/source`);
+  expect(calls[0].method).toBe('GET');
+});
+
+test('wdaRequest strips leading slash from wdaPath', async () => {
+  const { rest, calls } = client({ '/proxy/http': { status: 200, body: {} } });
+  await rest.wdaRequest('sess1', 'POST', '127.0.0.1', 8100, '/wda/pressButton', { name: 'home' });
+
+  expect(calls[0].url).toContain('/proxy/http/127.0.0.1/8100/wda/pressButton');
+});
+
+// ─── Error handling ───────────────────────────────────────────────────────────
+
+test('throws with status code on non-2xx GET response', async () => {
+  const { rest } = client({ '/devices': { status: 401, body: { error: 'Unauthorized' } } });
+  await expect(rest.listDevices()).rejects.toThrow('401');
+});
+
+test('throws with status code on non-2xx POST response', async () => {
+  const { rest } = client({ '/sessions': { status: 422, body: { error: 'Bad request' } } });
+  await expect(rest.createSession({ device: { os: 'IOS' } })).rejects.toThrow('422');
+});
+
+test('throws with status code on non-2xx DELETE response', async () => {
+  const { rest } = client({ '/sessions/x': { status: 500, body: {} } });
+  await expect(rest.deleteSession('x')).rejects.toThrow('500');
+});

--- a/packages/driver-saucelabs/src/rest-client.ts
+++ b/packages/driver-saucelabs/src/rest-client.ts
@@ -118,8 +118,9 @@ function ipaFilenameFromUrl(url: string): string {
   return version ? `${version}-${base}` : base;
 }
 
-/** Bundle ID used when launching WebDriverAgent on the device. */
-export const DEFAULT_WDA_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner.xctrunner';
+/** Bundle ID used when launching WebDriverAgent on the device. Falls back to SAUCE_WDA_BUNDLE_ID env var when omitted. */
+export const DEFAULT_WDA_BUNDLE_ID =
+  process.env['SAUCE_WDA_BUNDLE_ID'] ?? 'com.facebook.WebDriverAgentRunner.xctrunner';
 
 /** HTTP client for the Sauce Labs RDC v2 and App Storage APIs, used to manage sessions, devices, and app artifacts. */
 export class RestClient {

--- a/packages/driver-saucelabs/src/rest-client.ts
+++ b/packages/driver-saucelabs/src/rest-client.ts
@@ -1,0 +1,488 @@
+import createDebug from 'debug';
+
+const debug = createDebug('mw:driver-saucelabs:rest');
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export type SessionState = 'PENDING' | 'CREATING' | 'ACTIVE' | 'CLOSING' | 'CLOSED' | 'ERRORED';
+export type DeviceOs = 'ANDROID' | 'IOS';
+
+export interface SessionLinks {
+  ioWebsocketUrl: string;
+  eventsWebsocketUrl: string;
+  liveViewUrl?: string;
+  adbUrl?: string | null;
+}
+
+export interface SessionDevice {
+  descriptor: string;
+  deviceName?: string;
+  os: DeviceOs;
+  osVersion?: string;
+}
+
+export interface Session {
+  id: string;
+  state: SessionState;
+  device?: SessionDevice;
+  links?: SessionLinks;
+}
+
+export interface SessionCreation {
+  id: string;
+  state: SessionState;
+}
+
+export interface DeviceDescriptor {
+  id: string;
+  name: string;
+  os: DeviceOs;
+  osVersion?: string;
+  resolutionWidth?: number;
+  resolutionHeight?: number;
+  pixelsPerPoint?: number;
+  defaultOrientation?: string;
+  isPrivate?: boolean;
+  isTablet?: boolean;
+  modelNumber?: string;
+}
+
+export interface DeviceStatus {
+  descriptor: string;
+  isPrivateDevice: boolean;
+  state: string;
+  inUseBy?: Array<{ username: string }>;
+}
+
+export interface DeviceStatusResponse {
+  devices: DeviceStatus[];
+}
+
+export interface ExecuteShellCommandResponse {
+  stdout: string;
+}
+
+export interface AppInstallationStatus {
+  installationId?: string;
+  app?: string;
+  status: string;
+}
+
+export interface ListAppInstallationsResponse {
+  appInstallations: AppInstallationStatus[];
+}
+
+export interface LaunchWebDriverAgentResponse {
+  status: string;
+}
+
+export interface CheckWebDriverAgentStatusResponse {
+  state: string;
+  devicePort?: number;
+  hostPort?: number;
+}
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+export type Region = 'us-west-1' | 'eu-central-1' | 'us-east-4';
+
+function regionToBaseUrl(region: Region): string {
+  return `https://api.${region}.saucelabs.com/rdc/v2`;
+}
+
+function regionToStorageUrl(region: Region): string {
+  return `https://api.${region}.saucelabs.com/v1/storage/upload`;
+}
+
+function regionToStorageFilesUrl(region: Region): string {
+  return `https://api.${region}.saucelabs.com/v1/storage/files`;
+}
+
+// Repackages a WDA zip (containing .app at root) into an IPA (Payload/<App>.app/...)
+async function repackageToIpa(zipBuffer: Buffer): Promise<Buffer> {
+  const { default: AdmZip } = await import('adm-zip');
+  const input = new AdmZip(zipBuffer);
+  const output = new AdmZip();
+  for (const entry of input.getEntries()) {
+    output.addFile(`Payload/${entry.entryName}`, entry.getData(), '', entry.attr);
+  }
+  return output.toBuffer();
+}
+
+// Derives a versioned IPA filename from the source URL, e.g.
+// .../v15.0.0/WebDriverAgentRunner-Runner.zip → v15.0.0-WebDriverAgentRunner-Runner.ipa
+function ipaFilenameFromUrl(url: string): string {
+  const parts = new URL(url).pathname.split('/').filter(Boolean);
+  const base = (parts.at(-1) ?? 'wda.zip').replace(/\.zip$/i, '.ipa');
+  const version = parts.at(-2);
+  return version ? `${version}-${base}` : base;
+}
+
+/** Bundle ID used when launching WebDriverAgent on the device. */
+export const DEFAULT_WDA_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner.xctrunner';
+
+/** HTTP client for the Sauce Labs RDC v2 and App Storage APIs, used to manage sessions, devices, and app artifacts. */
+export class RestClient {
+  private readonly baseUrl: string;
+  private readonly storageUrl: string;
+  private readonly storageFilesUrl: string;
+  private readonly authHeader: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(
+    username: string,
+    accessKey: string,
+    region: Region = 'us-west-1',
+    _fetchFn?: typeof globalThis.fetch,
+  ) {
+    this.baseUrl = regionToBaseUrl(region);
+    this.storageUrl = regionToStorageUrl(region);
+    this.storageFilesUrl = regionToStorageFilesUrl(region);
+    this.authHeader = `Basic ${Buffer.from(`${username}:${accessKey}`).toString('base64')}`;
+    this.fetchFn = _fetchFn ?? globalThis.fetch;
+  }
+
+  // ─── Session ──────────────────────────────────────────────────────────────
+
+  /** Creates a new RDC session and returns its ID and initial state. */
+  async createSession(body: {
+    device: { os: DeviceOs; deviceName?: string };
+    configuration?: { sessionDuration?: string };
+  }): Promise<SessionCreation> {
+    debug('createSession %o', body);
+    return this.post<SessionCreation>('/sessions', body);
+  }
+
+  /** Fetches the current state and WebSocket links for an existing session. */
+  async getSession(sessionId: string): Promise<Session> {
+    debug('getSession %s', sessionId);
+    return this.get<Session>(`/sessions/${sessionId}`);
+  }
+
+  /** Terminates a session and releases the device back to the pool; tolerates 404 if the session already closed. */
+  async deleteSession(sessionId: string): Promise<void> {
+    debug('deleteSession %s', sessionId);
+    await this.delete(`/sessions/${sessionId}`);
+  }
+
+  // ─── Devices ──────────────────────────────────────────────────────────────
+
+  /** Returns the full catalog of devices available in the account's RDC pool. */
+  async listDevices(): Promise<DeviceDescriptor[]> {
+    debug('listDevices');
+    return this.get<DeviceDescriptor[]>('/devices');
+  }
+
+  /** Returns real-time availability state (AVAILABLE / IN_USE) for all devices in the pool. */
+  async listDeviceStatus(): Promise<DeviceStatusResponse> {
+    debug('listDeviceStatus');
+    return this.get<DeviceStatusResponse>('/devices/status');
+  }
+
+  // ─── Device interactions ──────────────────────────────────────────────────
+
+  /** Captures the current device screen and returns the raw PNG bytes. */
+  async takeScreenshot(sessionId: string): Promise<Buffer> {
+    debug('takeScreenshot %s', sessionId);
+    const url = `${this.baseUrl}/sessions/${sessionId}/device/takeScreenshot`;
+    const response = await this.fetchFn(url, {
+      method: 'POST',
+      headers: { Authorization: this.authHeader },
+    });
+    if (!response.ok) {
+      throw new Error(`takeScreenshot failed: ${response.status} ${response.statusText}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  /** Applies device-level settings such as orientation or animation state to the active session. */
+  async applySettings(sessionId: string, settings: {
+    orientation?: 'PORTRAIT' | 'LANDSCAPE';
+    animations?: boolean;
+  }): Promise<void> {
+    debug('applySettings %s %o', sessionId, settings);
+    await this.postNoContent(`/sessions/${sessionId}/device/applySettings`, settings);
+  }
+
+  /** Launches an already-installed app by bundle ID (iOS) or package/activity name (Android). */
+  async launchApp(sessionId: string, opts: {
+    bundleId?: string;
+    packageName?: string;
+    activityName?: string;
+  }): Promise<void> {
+    debug('launchApp %s %o', sessionId, opts);
+    await this.postNoContent(`/sessions/${sessionId}/device/launchApp`, opts);
+  }
+
+  /** Installs an app from Sauce Storage onto the device, optionally launching it immediately after. */
+  async installApp(
+    sessionId: string,
+    storageRef: string,
+    opts: { launchAfterInstall?: boolean } = {},
+  ): Promise<AppInstallationStatus> {
+    debug('installApp %s storage=%s launch=%s', sessionId, storageRef, opts.launchAfterInstall ?? false);
+    return this.post<AppInstallationStatus>(`/sessions/${sessionId}/device/installApp`, {
+      app: storageRef,
+      enableInstrumentation: true,
+      ...(opts.launchAfterInstall ? { launchAfterInstall: true } : {}),
+    });
+  }
+
+  /** Returns the list of pending and completed app installation records for a session. */
+  async listAppInstallations(sessionId: string): Promise<ListAppInstallationsResponse> {
+    debug('listAppInstallations %s', sessionId);
+    return this.post<ListAppInstallationsResponse>(`/sessions/${sessionId}/device/listAppInstallations`, {});
+  }
+
+  /** Removes an installed app from the device by bundle ID (iOS) or package name (Android). */
+  async uninstallApp(sessionId: string, opts: {
+    bundleId?: string;
+    packageName?: string;
+  }): Promise<void> {
+    debug('uninstallApp %s %o', sessionId, opts);
+    await this.postNoContent(`/sessions/${sessionId}/device/uninstallApp`, opts);
+  }
+
+  /** Opens the given URL in the device's default browser. */
+  async openUrl(sessionId: string, url: string): Promise<void> {
+    debug('openUrl %s %s', sessionId, url);
+    await this.postNoContent(`/sessions/${sessionId}/device/openUrl`, { url });
+  }
+
+  /** Runs an adb shell command on the device and returns its stdout (Android only). */
+  async executeShellCommand(sessionId: string, command: string): Promise<string> {
+    debug('executeShellCommand %s %s', sessionId, command);
+    const result = await this.post<ExecuteShellCommandResponse>(
+      `/sessions/${sessionId}/device/executeShellCommand`,
+      { adbShellCommand: command },
+    );
+    return result.stdout;
+  }
+
+  // ─── WDA (iOS) ────────────────────────────────────────────────────────────
+
+  /** Starts the WebDriverAgent process on the device using the specified bundle ID. */
+  async launchWebDriverAgent(sessionId: string, opts: { bundleId?: string; app?: string } = {}): Promise<void> {
+    const bundleId = opts.bundleId ?? DEFAULT_WDA_BUNDLE_ID;
+    debug('launchWebDriverAgent %s bundleId=%s app=%s', sessionId, bundleId, opts.app);
+    const body: Record<string, string> = { bundleId };
+    if (opts.app) body['app'] = opts.app;
+    await this.postNoContent(`/sessions/${sessionId}/device/launchWebDriverAgent`, body);
+  }
+
+  /** Returns the current WDA launch state and the device port it is listening on once running. */
+  async checkWebDriverAgentStatus(sessionId: string): Promise<CheckWebDriverAgentStatusResponse> {
+    debug('checkWebDriverAgentStatus %s', sessionId);
+    return this.post<CheckWebDriverAgentStatusResponse>(
+      `/sessions/${sessionId}/device/checkWebDriverAgentStatus`,
+      {},
+    );
+  }
+
+  // ─── WDA HTTP proxy ───────────────────────────────────────────────────────
+
+  /** Proxies an HTTP request to WDA running on the device through the Sauce Labs reverse proxy. */
+  async wdaRequest<T = unknown>(
+    sessionId: string,
+    method: string,
+    wdaHost: string,
+    wdaPort: number,
+    wdaPath: string,
+    body?: unknown,
+  ): Promise<T> {
+    const path = wdaPath.startsWith('/') ? wdaPath.slice(1) : wdaPath;
+    const url = `${this.baseUrl}/sessions/${sessionId}/device/proxy/http/${wdaHost}/${wdaPort}/${path}`;
+    debug('wdaRequest %s %s', method, url);
+    const response = await this.fetchFn(url, {
+      method,
+      headers: {
+        Authorization: this.authHeader,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`WDA proxy ${method} ${wdaPath} failed: ${response.status} ${text}`);
+    }
+    const text = await response.text();
+    if (!text) return undefined as T;
+    return JSON.parse(text) as T;
+  }
+
+  // ─── App Storage upload ───────────────────────────────────────────────────
+
+  /** Uploads a local file to Sauce Labs App Storage and returns a `storage:<id>` ref. */
+  async uploadToStorage(filePath: string): Promise<string> {
+    debug('uploadToStorage %s', filePath);
+    const { readFile } = await import('node:fs/promises');
+    const { basename } = await import('node:path');
+
+    const content = await readFile(filePath);
+    const filename = basename(filePath);
+
+    const formData = new FormData();
+    const blob = new Blob([content]);
+    formData.append('payload', blob, filename);
+
+    const response = await this.fetchFn(this.storageUrl, {
+      method: 'POST',
+      headers: { Authorization: this.authHeader },
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error(`Storage upload failed: ${response.status} ${response.statusText}`);
+    }
+    const json = await response.json() as { item?: { id?: string } };
+    const id = json?.item?.id;
+    if (!id) {
+      throw new Error(`Storage upload response missing item.id: ${JSON.stringify(json)}`);
+    }
+    debug('uploaded %s (%d bytes) → storage:%s', filename, content.length, id);
+    return `storage:${id}`;
+  }
+
+  /** Downloads a file from an HTTPS URL and uploads it directly to Sauce Labs App Storage, returning a `storage:<id>` ref. */
+  async uploadUrlToStorage(url: string): Promise<string> {
+    debug('uploadUrlToStorage %s', url);
+    const filename = new URL(url).pathname.split('/').pop() ?? 'upload.zip';
+
+    const download = await this.fetchFn(url);
+    if (!download.ok) {
+      throw new Error(`Failed to download from ${url}: ${download.status} ${download.statusText}`);
+    }
+    const content = Buffer.from(await download.arrayBuffer());
+
+    const formData = new FormData();
+    formData.append('payload', new Blob([content]), filename);
+
+    const response = await this.fetchFn(this.storageUrl, {
+      method: 'POST',
+      headers: { Authorization: this.authHeader },
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error(`Storage upload failed: ${response.status} ${response.statusText}`);
+    }
+    const json = await response.json() as { item?: { id?: string } };
+    const id = json?.item?.id;
+    if (!id) {
+      throw new Error(`Storage upload response missing item.id: ${JSON.stringify(json)}`);
+    }
+    debug('uploaded %s (%d bytes) → storage:%s', filename, content.length, id);
+    return `storage:${id}`;
+  }
+
+  /** Searches Sauce Storage by exact filename and returns a `storage:<id>` ref if a match is found, otherwise null. */
+  async findInStorage(filename: string): Promise<string | null> {
+    debug('findInStorage %s', filename);
+    const url = `${this.storageFilesUrl}?q=${encodeURIComponent(filename)}&page_size=5`;
+    const response = await this.fetchFn(url, {
+      headers: { Authorization: this.authHeader },
+    });
+    if (!response.ok) {
+      debug('findInStorage failed: %s %s', response.status, response.statusText);
+      return null;
+    }
+    const json = await response.json() as { items?: Array<{ id?: string; name?: string }> };
+    const item = json.items?.find((i) => i.name === filename);
+    if (item?.id) {
+      debug('found %s in storage → storage:%s', filename, item.id);
+      return `storage:${item.id}`;
+    }
+    return null;
+  }
+
+  /** Ensures the WDA IPA is available in Sauce Storage — reuses an existing upload if found, otherwise downloads the zip, repackages it as an IPA, and uploads it. */
+  async uploadWdaToStorage(url: string): Promise<string> {
+    debug('uploadWdaToStorage %s', url);
+    const ipaFilename = ipaFilenameFromUrl(url);
+
+    const existing = await this.findInStorage(ipaFilename);
+    if (existing) {
+      debug('WDA already in storage: %s', ipaFilename);
+      return `storage:filename=${ipaFilename}`;
+    }
+
+    debug('downloading WDA zip from %s', url);
+    const download = await this.fetchFn(url);
+    if (!download.ok) {
+      throw new Error(`Failed to download WDA from ${url}: ${download.status} ${download.statusText}`);
+    }
+    const zipBuffer = Buffer.from(await download.arrayBuffer());
+
+    debug('repackaging WDA zip as IPA');
+    const ipaBuffer = await repackageToIpa(zipBuffer);
+
+    const formData = new FormData();
+    formData.append('payload', new Blob([ipaBuffer]), ipaFilename);
+    const response = await this.fetchFn(this.storageUrl, {
+      method: 'POST',
+      headers: { Authorization: this.authHeader },
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error(`Storage upload failed: ${response.status} ${response.statusText}`);
+    }
+    const json = await response.json() as { item?: { id?: string } };
+    const id = json?.item?.id;
+    if (!id) {
+      throw new Error(`Storage upload response missing item.id: ${JSON.stringify(json)}`);
+    }
+    debug('uploaded WDA as %s (id=%s)', ipaFilename, id);
+    return `storage:filename=${ipaFilename}`;
+  }
+
+  // ─── HTTP helpers ─────────────────────────────────────────────────────────
+
+  private async get<T>(path: string): Promise<T> {
+    const response = await this.fetchFn(`${this.baseUrl}${path}`, {
+      headers: { Authorization: this.authHeader },
+    });
+    if (!response.ok) {
+      throw new Error(`GET ${path} failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const response = await this.fetchFn(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: this.authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`POST ${path} failed: ${response.status} ${text}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private async postNoContent(path: string, body: unknown): Promise<void> {
+    const response = await this.fetchFn(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: this.authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`POST ${path} failed: ${response.status} ${text}`);
+    }
+  }
+
+  private async delete(path: string): Promise<void> {
+    const response = await this.fetchFn(`${this.baseUrl}${path}`, {
+      method: 'DELETE',
+      headers: { Authorization: this.authHeader },
+    });
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`DELETE ${path} failed: ${response.status} ${response.statusText}`);
+    }
+  }
+}

--- a/packages/driver-saucelabs/src/wda-client.ts
+++ b/packages/driver-saucelabs/src/wda-client.ts
@@ -1,6 +1,6 @@
 import createDebug from 'debug';
 import type { AppInfo, ViewNode } from '@mobilewright/protocol';
-import type { RestClient } from './rest-client.js';
+import type { RestClient, CheckWebDriverAgentStatusResponse } from './rest-client.js';
 import { DEFAULT_WDA_BUNDLE_ID } from './rest-client.js';
 
 const debug = createDebug('mw:driver-saucelabs:wda');
@@ -58,6 +58,7 @@ function parseXmlViewNode(xml: string): ViewNode[] {
       identifier: attrs['name'] || undefined,
       value: attrs['value'] || undefined,
       text: attrs['label'] || undefined,
+      placeholder: attrs['placeholderValue'] || undefined,
       isVisible: attrs['visible'] !== 'false',
       isEnabled: attrs['enabled'] !== 'false',
       bounds: { x, y, width: w, height: h },
@@ -104,32 +105,46 @@ export class WdaClient {
   private async ensureInitialised(): Promise<void> {
     if (this.initialised) return;
 
-    debug('launching WDA wdaBundleId=%s wdaStorageRef=%s', this.wdaBundleId, this.wdaStorageRef);
-    if (this.wdaStorageRef) {
-      await this.rest.installApp(this.sessionId, this.wdaStorageRef, { launchAfterInstall: true });
-      await this.rest.launchWebDriverAgent(this.sessionId, {
-        bundleId: this.wdaBundleId ?? DEFAULT_WDA_BUNDLE_ID,
-      });
+    // A prior WdaClient attached to the same Sauce Labs session (e.g. an earlier test
+    // reusing this session via the device pool) may have already launched WDA. The
+    // runner process outlives that client's own close() — which only tears down its
+    // WebDriver session, not the process — so re-launching here would 409 ("WDARunner
+    // already started"). Check current status first and skip launching if it's already up.
+    const existingStatus = await this.rest.checkWebDriverAgentStatus(this.sessionId).catch(() => undefined);
+    if (existingStatus?.state === 'RUNNING' && existingStatus.devicePort) {
+      debug('WDA already running on port %d, skipping launch', existingStatus.devicePort);
+      this.wdaHost = 'localhost';
+      this.wdaPort = existingStatus.devicePort;
     } else {
-      await this.rest.launchWebDriverAgent(this.sessionId, { bundleId: this.wdaBundleId });
-    }
+      debug('launching WDA wdaBundleId=%s wdaStorageRef=%s', this.wdaBundleId, this.wdaStorageRef);
+      if (this.wdaStorageRef) {
+        await this.rest.installApp(this.sessionId, this.wdaStorageRef, { launchAfterInstall: true });
+        await this.rest.launchWebDriverAgent(this.sessionId, {
+          bundleId: this.wdaBundleId ?? DEFAULT_WDA_BUNDLE_ID,
+        });
+      } else {
+        await this.rest.launchWebDriverAgent(this.sessionId, { bundleId: this.wdaBundleId });
+      }
 
-    const deadline = Date.now() + WDA_READY_TIMEOUT_MS;
-    let lastStatus: Awaited<ReturnType<typeof this.rest.checkWebDriverAgentStatus>> | undefined;
-    while (Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, WDA_POLL_INTERVAL_MS));
-      lastStatus = await this.rest.checkWebDriverAgentStatus(this.sessionId);
-      debug('WDA status: %j', lastStatus);
-      if (lastStatus.state === 'RUNNING' && lastStatus.devicePort) {
-        this.wdaHost = 'localhost';
-        this.wdaPort = lastStatus.devicePort;
-        break;
+      const deadline = Date.now() + WDA_READY_TIMEOUT_MS;
+      let lastStatus: CheckWebDriverAgentStatusResponse | undefined;
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, WDA_POLL_INTERVAL_MS));
+        lastStatus = await this.rest.checkWebDriverAgentStatus(this.sessionId);
+        debug('WDA status: %j', lastStatus);
+        if (lastStatus.state === 'RUNNING' && lastStatus.devicePort) {
+          this.wdaHost = 'localhost';
+          this.wdaPort = lastStatus.devicePort;
+          break;
+        }
+      }
+
+      if (!this.wdaHost || !this.wdaPort) {
+        throw new Error(`Timed out waiting for WDA to become RUNNING (last status: ${JSON.stringify(lastStatus)})`);
       }
     }
 
-    if (!this.wdaHost || !this.wdaPort) {
-      throw new Error(`Timed out waiting for WDA to become RUNNING (last status: ${JSON.stringify(lastStatus)})`);
-    }
+    const deadline = Date.now() + WDA_READY_TIMEOUT_MS;
 
     // WDA may not yet accept connections immediately after reaching RUNNING.
     // Retry POST /session until it succeeds or the deadline is hit.

--- a/packages/driver-saucelabs/src/wda-client.ts
+++ b/packages/driver-saucelabs/src/wda-client.ts
@@ -1,0 +1,227 @@
+import createDebug from 'debug';
+import type { AppInfo, ViewNode } from '@mobilewright/protocol';
+import type { RestClient } from './rest-client.js';
+import { DEFAULT_WDA_BUNDLE_ID } from './rest-client.js';
+
+const debug = createDebug('mw:driver-saucelabs:wda');
+
+const WDA_POLL_INTERVAL_MS = 2_000;
+const WDA_READY_TIMEOUT_MS = 120_000;
+
+interface WdaSessionResponse {
+  sessionId?: string;
+  value?: { sessionId?: string };
+}
+
+interface WdaSourceResponse {
+  value?: string;
+}
+
+interface WdaActiveAppResponse {
+  value?: {
+    bundleId?: string;
+    name?: string;
+  };
+}
+
+interface WdaAppsListResponse {
+  value?: Array<{ bundleId?: string; name?: string }>;
+}
+
+function parseXmlViewNode(xml: string): ViewNode[] {
+  // Minimal XML attribute parser — avoids a heavyweight XML dependency.
+  const root: ViewNode[] = [];
+  const stack: ViewNode[][] = [root];
+
+  const tagRe = /<(\/?)([A-Za-z][A-Za-z0-9_]*)([^>]*)>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRe.exec(xml)) !== null) {
+    const [, closing, tag, attrsRaw] = match;
+
+    if (closing) {
+      if (stack.length > 1) stack.pop();
+      continue;
+    }
+
+    const attrs = parseAttrs(attrsRaw);
+    const isSelfClosing = attrsRaw.trimEnd().endsWith('/');
+
+    const x = Number(attrs['x'] ?? 0);
+    const y = Number(attrs['y'] ?? 0);
+    const w = Number(attrs['width'] ?? attrs['bounds_width'] ?? 0);
+    const h = Number(attrs['height'] ?? attrs['bounds_height'] ?? 0);
+
+    const node: ViewNode = {
+      type: tag,
+      label: attrs['label'] || attrs['name'] || undefined,
+      identifier: attrs['name'] || undefined,
+      value: attrs['value'] || undefined,
+      text: attrs['label'] || undefined,
+      isVisible: attrs['visible'] !== 'false',
+      isEnabled: attrs['enabled'] !== 'false',
+      bounds: { x, y, width: w, height: h },
+      children: [],
+      raw: { ...attrs },
+    };
+
+    const parent = stack[stack.length - 1];
+    parent.push(node);
+
+    if (!isSelfClosing) {
+      stack.push(node.children);
+    }
+  }
+
+  return root;
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const re = /(\w[\w-]*)="([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) !== null) {
+    attrs[m[1]] = m[2];
+  }
+  return attrs;
+}
+
+/** Manages the WebDriverAgent session on an iOS device, providing view hierarchy, app control, and button press capabilities. */
+export class WdaClient {
+  private wdaSessionId: string | null = null;
+  private wdaHost: string | null = null;
+  private wdaPort: number | null = null;
+  private initialised = false;
+
+  constructor(
+    private readonly rest: RestClient,
+    private readonly sessionId: string,
+    private readonly wdaBundleId?: string,
+    private readonly wdaStorageRef?: string,
+  ) {}
+
+  /** Installs and starts WDA if not already running, polls until it is RUNNING, then opens a WebDriver session — retrying the session until WDA accepts connections. */
+  private async ensureInitialised(): Promise<void> {
+    if (this.initialised) return;
+
+    debug('launching WDA wdaBundleId=%s wdaStorageRef=%s', this.wdaBundleId, this.wdaStorageRef);
+    if (this.wdaStorageRef) {
+      await this.rest.installApp(this.sessionId, this.wdaStorageRef, { launchAfterInstall: true });
+      await this.rest.launchWebDriverAgent(this.sessionId, {
+        bundleId: this.wdaBundleId ?? DEFAULT_WDA_BUNDLE_ID,
+      });
+    } else {
+      await this.rest.launchWebDriverAgent(this.sessionId, { bundleId: this.wdaBundleId });
+    }
+
+    const deadline = Date.now() + WDA_READY_TIMEOUT_MS;
+    let lastStatus: Awaited<ReturnType<typeof this.rest.checkWebDriverAgentStatus>> | undefined;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, WDA_POLL_INTERVAL_MS));
+      lastStatus = await this.rest.checkWebDriverAgentStatus(this.sessionId);
+      debug('WDA status: %j', lastStatus);
+      if (lastStatus.state === 'RUNNING' && lastStatus.devicePort) {
+        this.wdaHost = 'localhost';
+        this.wdaPort = lastStatus.devicePort;
+        break;
+      }
+    }
+
+    if (!this.wdaHost || !this.wdaPort) {
+      throw new Error(`Timed out waiting for WDA to become RUNNING (last status: ${JSON.stringify(lastStatus)})`);
+    }
+
+    // WDA may not yet accept connections immediately after reaching RUNNING.
+    // Retry POST /session until it succeeds or the deadline is hit.
+    let resp: WdaSessionResponse | undefined;
+    let lastError: Error | undefined;
+    while (Date.now() < deadline) {
+      try {
+        resp = await this.proxy<WdaSessionResponse>('POST', '/session', { capabilities: {} });
+        break;
+      } catch (err) {
+        lastError = err as Error;
+        debug('WDA session attempt failed: %s', lastError.message);
+        await new Promise((r) => setTimeout(r, WDA_POLL_INTERVAL_MS));
+      }
+    }
+
+    if (!resp) {
+      throw new Error(`Timed out waiting for WDA to accept connections: ${lastError?.message}`);
+    }
+
+    const wdaSessionId = resp.sessionId ?? resp.value?.sessionId;
+    if (!wdaSessionId) throw new Error(`WDA session response missing sessionId: ${JSON.stringify(resp)}`);
+    this.wdaSessionId = wdaSessionId;
+    this.initialised = true;
+    debug('WDA session created: %s', wdaSessionId);
+    return;
+  }
+
+  /** Deletes the WDA WebDriver session, freeing resources on the device. */
+  async close(): Promise<void> {
+    if (!this.initialised || !this.wdaSessionId) return;
+    try {
+      await this.proxy('DELETE', `/session/${this.wdaSessionId}`, undefined);
+    } catch (err) {
+      debug('WDA session close error: %s', (err as Error).message);
+    }
+    this.wdaSessionId = null;
+    this.initialised = false;
+  }
+
+  /** Returns the iOS view hierarchy as a tree of ViewNodes parsed from WDA's XML page source. */
+  async getSource(): Promise<ViewNode[]> {
+    await this.ensureInitialised();
+    const resp = await this.proxy<WdaSourceResponse>('GET', `/session/${this.wdaSessionId}/source`, undefined);
+    const xml = resp?.value ?? '';
+    return parseXmlViewNode(xml);
+  }
+
+  /** Returns the bundle ID and name of the app currently in the foreground. */
+  async getActiveAppInfo(): Promise<AppInfo> {
+    await this.ensureInitialised();
+    const resp = await this.proxy<WdaActiveAppResponse>('GET', `/session/${this.wdaSessionId}/wda/activeAppInfo`, undefined);
+    return {
+      bundleId: resp?.value?.bundleId ?? '',
+      name: resp?.value?.name,
+    };
+  }
+
+  /** Returns the list of apps currently running on the device according to WDA. */
+  async listApps(): Promise<AppInfo[]> {
+    await this.ensureInitialised();
+    const resp = await this.proxy<WdaAppsListResponse>('GET', '/wda/apps/list', undefined);
+    const apps = resp?.value ?? [];
+    return apps.map((a) => ({ bundleId: a.bundleId ?? '', name: a.name }));
+  }
+
+  /** Force-terminates a running app by its bundle ID. */
+  async terminateApp(bundleId: string): Promise<void> {
+    await this.ensureInitialised();
+    await this.proxy('POST', `/session/${this.wdaSessionId}/wda/apps/terminate`, { bundleId });
+  }
+
+  /** Sends a hardware button press (e.g. volumeUp, volumeDown, power) through WDA. */
+  async pressButton(name: string): Promise<void> {
+    await this.ensureInitialised();
+    await this.proxy('POST', `/session/${this.wdaSessionId}/wda/pressButton`, { name });
+  }
+
+  /** Sets the text value of a UI element by its WDA element ID. */
+  async setValue(elementId: string, text: string): Promise<void> {
+    await this.ensureInitialised();
+    await this.proxy('POST', `/session/${this.wdaSessionId}/element/${elementId}/value`, { value: [text] });
+  }
+
+  private proxy<T = unknown>(method: string, wdaPath: string, body: unknown): Promise<T> {
+    return this.rest.wdaRequest<T>(
+      this.sessionId,
+      method,
+      this.wdaHost!,
+      this.wdaPort!,
+      wdaPath,
+      body,
+    );
+  }
+}

--- a/packages/driver-saucelabs/src/wda-client.ts
+++ b/packages/driver-saucelabs/src/wda-client.ts
@@ -206,7 +206,7 @@ export class WdaClient {
   /** Returns the list of apps currently running on the device according to WDA. */
   async listApps(): Promise<AppInfo[]> {
     await this.ensureInitialised();
-    const resp = await this.proxy<WdaAppsListResponse>('GET', '/wda/apps/list', undefined);
+    const resp = await this.proxy<WdaAppsListResponse>('GET', `/session/${this.wdaSessionId}/wda/apps/list`, undefined);
     const apps = resp?.value ?? [];
     return apps.map((a) => ({ bundleId: a.bundleId ?? '', name: a.name }));
   }

--- a/packages/driver-saucelabs/tsconfig.json
+++ b/packages/driver-saucelabs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../protocol" }
+  ]
+}

--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -198,6 +198,40 @@ test.describe('Locator', () => {
 
       await expect(locator.clear()).rejects.toThrow(LocatorError);
     });
+
+    test('does not throw when the cleared field reports its placeholder as the value (WDA on iOS)', async () => {
+      // Some platforms (iOS/WDA) report an empty field's value as its
+      // placeholder text rather than an empty string.
+      const emptyFieldReportingPlaceholder: ViewNode[] = [
+        node({
+          type: 'TextField',
+          identifier: 'emailField',
+          value: 'Coupon code',
+          placeholder: 'Coupon code',
+          bounds: { x: 20, y: 200, width: 350, height: 44 },
+        }),
+      ];
+      const driver = createMockDriver(emptyFieldReportingPlaceholder);
+      const locator = new Locator(driver, { kind: 'testId', value: 'emailField' });
+
+      await expect(locator.clear()).resolves.toBeUndefined();
+    });
+
+    test('still throws when the field has residual text different from its placeholder', async () => {
+      const fieldWithResidualText: ViewNode[] = [
+        node({
+          type: 'TextField',
+          identifier: 'emailField',
+          value: 'leftover',
+          placeholder: 'Coupon code',
+          bounds: { x: 20, y: 200, width: 350, height: 44 },
+        }),
+      ];
+      const driver = createMockDriver(fieldWithResidualText);
+      const locator = new Locator(driver, { kind: 'testId', value: 'emailField' });
+
+      await expect(locator.clear()).rejects.toThrow(LocatorError);
+    });
   });
 
   test.describe('fill', () => {

--- a/packages/mobilewright-core/src/locator.ts
+++ b/packages/mobilewright-core/src/locator.ts
@@ -35,6 +35,9 @@ export interface ScrollIntoViewOptions {
 const DEFAULT_TIMEOUT = 5_000;
 const DEFAULT_POLL_INTERVAL = 100;
 const DEFAULT_STABILITY_DELAY = 50;
+// Grace window for the post-clear value check: the accessibility snapshot can lag
+// briefly behind the actual on-device UI state right after a clearText() call.
+const CLEAR_VERIFY_TIMEOUT = 1_000;
 
 export class Locator {
   /** Create a root locator that searches the entire view hierarchy. */
@@ -201,17 +204,28 @@ export class Locator {
     await this.driver.clearText();
 
     // Verify the clear actually emptied the field; if the driver's select-all
-    // didn't take, only a single character is removed and we'd otherwise
-    // silently leave residual text for fill() to append to.
-    if ((await this._currentValue()) !== '') {
-      throw new LocatorError('Failed to clear element', this.strategy);
+    // didn't take, only a single character is removed, and we'd otherwise
+    // silently leave residual text for fill() to append to. Some platforms
+    // (iOS/WDA) report an empty field's value as its placeholder text rather
+    // than an empty string, so treat that as cleared too. The accessibility
+    // snapshot can also lag briefly behind the actual UI state right after
+    // clearText(), so poll for a short grace window before failing.
+    const deadline = Date.now() + CLEAR_VERIFY_TIMEOUT;
+    while (true) {
+      const node = await this._currentNode();
+      const value = node?.value ?? '';
+      if (value === '' || value === node?.placeholder) return;
+      if (Date.now() >= deadline) {
+        throw new LocatorError('Failed to clear element', this.strategy);
+      }
+      await sleep(DEFAULT_POLL_INTERVAL);
     }
   }
 
-  /** Read the element's current value from the latest hierarchy, '' if absent. */
-  private async _currentValue(): Promise<string> {
+  /** Read the element's current node from the latest hierarchy, null if absent. */
+  private async _currentNode(): Promise<ViewNode | null> {
     const roots = await this.driver.getViewHierarchy();
-    return queryAll(roots, this.strategy)[0]?.value ?? '';
+    return queryAll(roots, this.strategy)[0] ?? null;
   }
 
   async screenshot(opts?: { timeout?: number }): Promise<Buffer> {

--- a/packages/mobilewright/package.json
+++ b/packages/mobilewright/package.json
@@ -37,6 +37,7 @@
     "@mobilewright/core": "^0.0.1",
     "@mobilewright/driver-mobilecli": "^0.0.1",
     "@mobilewright/driver-mobilenext": "^0.0.1",
+    "@mobilewright/driver-saucelabs": "*",
     "@mobilewright/protocol": "^0.0.1",
     "commander": "^14.0.3",
     "debug": "^4.4.3",

--- a/packages/mobilewright/package.json
+++ b/packages/mobilewright/package.json
@@ -37,7 +37,7 @@
     "@mobilewright/core": "^0.0.1",
     "@mobilewright/driver-mobilecli": "^0.0.1",
     "@mobilewright/driver-mobilenext": "^0.0.1",
-    "@mobilewright/driver-saucelabs": "*",
+    "@mobilewright/driver-saucelabs": "^0.0.1",
     "@mobilewright/inspector": "^0.0.1",
     "@mobilewright/protocol": "^0.0.1",
     "commander": "^14.0.3",

--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -29,6 +29,10 @@ export interface MobilewrightUseOptions {
   appLaunchTimeout?: number;
   /** Timeout for app installation (installApps) in ms. Default: none. */
   installTimeout?: number;
+  /** Record a video of each test. Default: 'off'. */
+  video?: 'off' | 'on' | 'retain-on-failure' | 'on-first-retry';
+  /** Capture screenshots. Default: 'off'. */
+  screenshot?: 'off' | 'on' | 'only-on-failure';
 }
 
 export interface MobilewrightExpectConfig {
@@ -78,7 +82,22 @@ export interface DriverConfigMobileNext {
   uploadTimeout?: number;
 }
 
-export type DriverConfig = DriverConfigMobilecli | DriverConfigMobileNext;
+export interface DriverConfigSauceLabs {
+  type: 'saucelabs';
+  /** Falls back to SAUCE_USERNAME env var when omitted. */
+  username?: string;
+  /** Falls back to SAUCE_ACCESS_KEY env var when omitted. */
+  accessKey?: string;
+  region?: 'us-west-1' | 'eu-central-1' | 'us-east-4';
+  /** Timeout waiting for a cloud device to be allocated, in ms. Default: 300000 (5 min). */
+  allocationTimeout?: number;
+  /** ISO-8601 duration for max session length e.g. 'PT1H'. */
+  sessionDuration?: string;
+  /** Custom WDA fork bundle ID for iOS. Omit to use the Sauce Labs default WDA. */
+  iosWdaBundleId?: string;
+}
+
+export type DriverConfig = DriverConfigMobilecli | DriverConfigMobileNext | DriverConfigSauceLabs;
 
 export interface MobilewrightConfig {
   // ── Mobile-specific ─────────────────────────────────────────

--- a/packages/mobilewright/src/device-pool/adapters/saucelabs-allocator.ts
+++ b/packages/mobilewright/src/device-pool/adapters/saucelabs-allocator.ts
@@ -1,0 +1,42 @@
+import createDebug from 'debug';
+import { SauceLabsDriver } from '@mobilewright/driver-saucelabs';
+import type { SauceLabsDriverOptions } from '@mobilewright/driver-saucelabs';
+import type { AllocationCriteria, AllocateResult, DeviceAllocator } from '../application/ports.js';
+
+const debug = createDebug('mw:device-pool:saucelabs');
+
+export interface SauceLabsAllocatorOptions {
+  driverOptions: SauceLabsDriverOptions;
+}
+
+export class SauceLabsAllocator implements DeviceAllocator {
+  private readonly driverOptions: SauceLabsDriverOptions;
+  private readonly activeDrivers = new Map<string, SauceLabsDriver>();
+
+  constructor(options: SauceLabsAllocatorOptions) {
+    this.driverOptions = options.driverOptions;
+  }
+
+  async allocate(criteria: AllocationCriteria): Promise<AllocateResult> {
+    debug('allocating device (criteria=%o)', criteria);
+    const driver = new SauceLabsDriver(this.driverOptions);
+    const session = await driver.connect({
+      platform: criteria.platform ?? 'android',
+      deviceName: criteria.deviceNamePattern ? new RegExp(criteria.deviceNamePattern) : undefined,
+      deviceId: criteria.deviceId,
+    });
+    this.activeDrivers.set(session.deviceId, driver);
+    debug('allocated device %s (platform=%s)', session.deviceId, session.platform);
+    return { deviceId: session.deviceId, platform: session.platform, driver: 'saucelabs' };
+  }
+
+  async release(deviceId: string): Promise<void> {
+    debug('releasing device %s', deviceId);
+    const driver = this.activeDrivers.get(deviceId);
+    if (driver) {
+      this.activeDrivers.delete(deviceId);
+      await driver.disconnect();
+      debug('released device %s', deviceId);
+    }
+  }
+}

--- a/packages/mobilewright/src/device-pool/adapters/saucelabs-allocator.ts
+++ b/packages/mobilewright/src/device-pool/adapters/saucelabs-allocator.ts
@@ -11,31 +11,32 @@ export interface SauceLabsAllocatorOptions {
 
 export class SauceLabsAllocator implements DeviceAllocator {
   private readonly driverOptions: SauceLabsDriverOptions;
-  private readonly activeDrivers = new Map<string, SauceLabsDriver>();
+  private readonly sessionsByDeviceId = new Map<string, string>();
 
   constructor(options: SauceLabsAllocatorOptions) {
     this.driverOptions = options.driverOptions;
   }
 
+  // Reserves the device via a session-only allocation so the worker that
+  // actually runs the test can attach to this same session
   async allocate(criteria: AllocationCriteria): Promise<AllocateResult> {
     debug('allocating device (criteria=%o)', criteria);
-    const driver = new SauceLabsDriver(this.driverOptions);
-    const session = await driver.connect({
-      platform: criteria.platform ?? 'android',
+    const platform = criteria.platform ?? 'android';
+    const { sessionId, deviceId } = await SauceLabsDriver.allocateSession(this.driverOptions, {
+      platform,
       deviceName: criteria.deviceNamePattern ? new RegExp(criteria.deviceNamePattern) : undefined,
-      deviceId: criteria.deviceId,
     });
-    this.activeDrivers.set(session.deviceId, driver);
-    debug('allocated device %s (platform=%s)', session.deviceId, session.platform);
-    return { deviceId: session.deviceId, platform: session.platform, driver: 'saucelabs' };
+    this.sessionsByDeviceId.set(deviceId, sessionId);
+    debug('allocated device %s (session=%s)', deviceId, sessionId);
+    return { deviceId, platform, driver: 'saucelabs', sessionId };
   }
 
   async release(deviceId: string): Promise<void> {
-    debug('releasing device %s', deviceId);
-    const driver = this.activeDrivers.get(deviceId);
-    if (driver) {
-      this.activeDrivers.delete(deviceId);
-      await driver.disconnect();
+    const sessionId = this.sessionsByDeviceId.get(deviceId);
+    if (sessionId) {
+      this.sessionsByDeviceId.delete(deviceId);
+      debug('releasing device %s (session=%s)', deviceId, sessionId);
+      await SauceLabsDriver.releaseSession(this.driverOptions, sessionId);
       debug('released device %s', deviceId);
     }
   }

--- a/packages/mobilewright/src/device-pool/adapters/saucelabs-allocator.ts
+++ b/packages/mobilewright/src/device-pool/adapters/saucelabs-allocator.ts
@@ -34,9 +34,9 @@ export class SauceLabsAllocator implements DeviceAllocator {
   async release(deviceId: string): Promise<void> {
     const sessionId = this.sessionsByDeviceId.get(deviceId);
     if (sessionId) {
-      this.sessionsByDeviceId.delete(deviceId);
       debug('releasing device %s (session=%s)', deviceId, sessionId);
       await SauceLabsDriver.releaseSession(this.driverOptions, sessionId);
+      this.sessionsByDeviceId.delete(deviceId);
       debug('released device %s', deviceId);
     }
   }

--- a/packages/mobilewright/src/device-pool/allocator-factory.ts
+++ b/packages/mobilewright/src/device-pool/allocator-factory.ts
@@ -2,7 +2,8 @@ import { DEFAULT_URL, MobilecliDriver } from '@mobilewright/driver-mobilecli';
 import { ensureMobilecliReachable } from '../server.js';
 import { MobilecliAllocator } from './adapters/mobilecli-allocator.js';
 import { MobileNextAllocator } from './adapters/mobilenext-allocator.js';
-import type { MobilewrightConfig, DriverConfigMobileNext } from '../config.js';
+import { SauceLabsAllocator } from './adapters/saucelabs-allocator.js';
+import type { MobilewrightConfig, DriverConfigMobileNext, DriverConfigSauceLabs } from '../config.js';
 import type { DeviceAllocator } from './application/ports.js';
 
 export interface AllocatorResult {
@@ -31,5 +32,20 @@ export async function createAllocator(config: MobilewrightConfig): Promise<Alloc
     return { allocator };
   }
 
-  throw new Error(`Unsupported driver type: "${driverType}". Supported types: "mobilecli", "mobilenext".`);
+  if (driverType === 'saucelabs') {
+    const slConfig = config.driver as DriverConfigSauceLabs;
+    const allocator = new SauceLabsAllocator({
+      driverOptions: {
+        username: slConfig.username,
+        accessKey: slConfig.accessKey,
+        region: slConfig.region,
+        allocationTimeout: slConfig.allocationTimeout,
+        sessionDuration: slConfig.sessionDuration,
+        iosWdaBundleId: slConfig.iosWdaBundleId,
+      },
+    });
+    return { allocator };
+  }
+
+  throw new Error(`Unsupported driver type: "${driverType}". Supported types: "mobilecli", "mobilenext", "saucelabs".`);
 }

--- a/packages/mobilewright/src/device-pool/application/device-pool.ts
+++ b/packages/mobilewright/src/device-pool/application/device-pool.ts
@@ -143,6 +143,7 @@ export class DevicePool {
       model: slot.model,
       osVersion: slot.osVersion,
       type: slot.type,
+      sessionId: slot.sessionId,
     });
   }
 
@@ -197,7 +198,7 @@ export class DevicePool {
       this.allocator.release(result.deviceId).catch(() => {});
       return;
     }
-    slot.markAvailable(result.deviceId, result.platform, result.driver, result.model, result.osVersion, result.type);
+    slot.markAvailable(result.deviceId, result.platform, result.driver, result.model, result.osVersion, result.type, result.sessionId);
     this.waiters.unshift(waiter);
     this.pump();
   }

--- a/packages/mobilewright/src/device-pool/application/ports.ts
+++ b/packages/mobilewright/src/device-pool/application/ports.ts
@@ -27,6 +27,8 @@ export interface AllocateResult {
   model?: string;
   osVersion?: string;
   type?: DeviceType;
+  /** Driver-specific session identifier to attach to via `ConnectionConfig.sessionId` (Sauce Labs only). */
+  sessionId?: string;
 }
 
 /**
@@ -52,6 +54,8 @@ export interface AllocationHandle {
   model?: string;
   osVersion?: string;
   type?: DeviceType;
+  /** Driver-specific session identifier to attach to via `ConnectionConfig.sessionId` (Sauce Labs only). */
+  sessionId?: string;
 }
 
 /**

--- a/packages/mobilewright/src/device-pool/domain/device-slot.ts
+++ b/packages/mobilewright/src/device-pool/domain/device-slot.ts
@@ -18,6 +18,7 @@ export class DeviceSlot {
   private _model?: string;
   private _osVersion?: string;
   private _type?: DeviceType;
+  private _sessionId?: string;
   private readonly _installedApps = new Set<string>();
 
   get state(): DeviceSlotState {
@@ -52,7 +53,11 @@ export class DeviceSlot {
     return this._type;
   }
 
-  markAvailable(deviceId: string, platform: Platform, driver?: string, model?: string, osVersion?: string, type?: DeviceType): void {
+  get sessionId(): string | undefined {
+    return this._sessionId;
+  }
+
+  markAvailable(deviceId: string, platform: Platform, driver?: string, model?: string, osVersion?: string, type?: DeviceType, sessionId?: string): void {
     if (this._state !== 'allocating') {
       throw new DeviceSlotStateError(
         `markAvailable requires state 'allocating', got '${this._state}'`,
@@ -65,6 +70,7 @@ export class DeviceSlot {
     this._model = model;
     this._osVersion = osVersion;
     this._type = type;
+    this._sessionId = sessionId;
   }
 
   claim(allocationId: string): void {

--- a/packages/mobilewright/src/index.ts
+++ b/packages/mobilewright/src/index.ts
@@ -9,7 +9,7 @@ export { expect } from '@mobilewright/core';
 export { Device, Screen, Locator, MobileWebViewPage, MobileWebViewLocator, Page, WebLocator } from '@mobilewright/core';
 
 // Configuration
-export { defineConfig, loadConfig, type MobilewrightConfig, type MobilewrightProjectConfig, type MobilewrightUseOptions, type DriverConfig, type DriverConfigMobilecli, type DriverConfigMobileNext } from './config.js';
+export { defineConfig, loadConfig, type MobilewrightConfig, type MobilewrightProjectConfig, type MobilewrightUseOptions, type DriverConfig, type DriverConfigMobilecli, type DriverConfigMobileNext, type DriverConfigSauceLabs } from './config.js';
 
 // Errors
 export { MobilewrightError } from './errors.js';

--- a/packages/mobilewright/src/launchers.ts
+++ b/packages/mobilewright/src/launchers.ts
@@ -41,6 +41,8 @@ export interface ConnectDeviceParams {
   appLaunchTimeout?: number;
   installTimeout?: number;
   deviceSettings?: DeviceSettings;
+  /** Attach to an existing driver session instead of allocating a new device (Sauce Labs only). */
+  sessionId?: string;
 }
 
 export interface FindDeviceParams {
@@ -91,6 +93,7 @@ export async function connectDevice(params: ConnectDeviceParams): Promise<Device
     deviceId: params.deviceId,
     deviceType: params.deviceType,
     timeout: params.timeout,
+    sessionId: params.sessionId,
   });
 
   const settings = params.deviceSettings;

--- a/packages/mobilewright/src/launchers.ts
+++ b/packages/mobilewright/src/launchers.ts
@@ -2,9 +2,10 @@ import type { Platform, DeviceInfo, DeviceType, DeviceSettings, MobilewrightDriv
 import { Device } from '@mobilewright/core';
 import { MobilecliDriver, DEFAULT_URL } from '@mobilewright/driver-mobilecli';
 import { MobileNextDriver } from '@mobilewright/driver-mobilenext';
+import { SauceLabsDriver } from '@mobilewright/driver-saucelabs';
 import { ensureMobilecliReachable } from './server.js';
 import { toArray } from './config.js';
-import type { DriverConfig } from './config.js';
+import type { DriverConfig, DriverConfigSauceLabs } from './config.js';
 
 export interface LaunchOptions {
   bundleId?: string;
@@ -56,6 +57,17 @@ export function createDriver(driverConfig?: DriverConfig, url?: string): Mobilew
       region: driverConfig.region,
       apiKey: driverConfig.apiKey,
       allocationTimeout: driverConfig.allocationTimeout,
+    });
+  }
+  if (driverConfig?.type === 'saucelabs') {
+    const slConfig = driverConfig as DriverConfigSauceLabs;
+    return new SauceLabsDriver({
+      username: slConfig.username,
+      accessKey: slConfig.accessKey,
+      region: slConfig.region,
+      allocationTimeout: slConfig.allocationTimeout,
+      sessionDuration: slConfig.sessionDuration,
+      iosWdaBundleId: slConfig.iosWdaBundleId,
     });
   }
   return new MobilecliDriver({ url });

--- a/packages/mobilewright/tsconfig.json
+++ b/packages/mobilewright/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "../protocol" },
     { "path": "../mobilewright-core" },
     { "path": "../driver-mobilecli" },
-    { "path": "../driver-mobilenext" }
+    { "path": "../driver-mobilenext" },
+    { "path": "../driver-saucelabs" }
   ]
 }

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -80,11 +80,15 @@ export interface ConnectionConfig {
   osVersion?: string;
   /** Connection timeout in ms */
   timeout?: number;
+  /** Attach to an existing driver session instead of allocating a new device (Sauce Labs only). */
+  sessionId?: string;
 }
 
 export interface Session {
   deviceId: string;
   platform: Platform;
+  /** Driver-specific session identifier, present when the driver supports attaching via `ConnectionConfig.sessionId`. */
+  sessionId?: string;
 }
 
 // ─── Device Settings ─────────────────────────────────────────────

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -101,7 +101,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
     }
 
     for (const appPath of toArray(merged.installApps)) {
-      assertValidZipFile(appPath);
+      if (!appPath.startsWith('https://')) assertValidZipFile(appPath);
     }
 
     const client = getClient();

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -146,6 +146,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
       appLaunchTimeout: merged.use?.appLaunchTimeout,
       installTimeout: merged.use?.installTimeout,
       deviceSettings: { animations: merged.use?.animations },
+      sessionId: handle.sessionId,
     });
     debug('connected to device %s', handle.deviceId);
 
@@ -217,8 +218,8 @@ export const test = base.extend<MobilewrightTestFixtures>({
         const buf = await device.screen.screenshot();
         const label = failed ? 'screenshot-on-failure' : 'screenshot';
         await testInfo.attach(label, { body: buf, contentType: 'image/png' });
-      } catch {
-        // device may be disconnected
+      } catch (err) {
+        debug('screenshot attach failed: %o', err);
       }
     }
 
@@ -227,8 +228,8 @@ export const test = base.extend<MobilewrightTestFixtures>({
         try {
           const buf = await device.screen.screenshot();
           await testInfo.attach('screenshot-on-failure', { body: buf, contentType: 'image/png' });
-        } catch {
-          // device may be disconnected
+        } catch (err) {
+          debug('screenshot-on-failure attach failed: %o', err);
         }
       }
       if (viewTree === 'on-failure') {
@@ -238,8 +239,8 @@ export const test = base.extend<MobilewrightTestFixtures>({
             body: Buffer.from(JSON.stringify(tree, null, 2)),
             contentType: 'application/json',
           });
-        } catch {
-          // device may be disconnected
+        } catch (err) {
+          debug('view-tree-on-failure attach failed: %o', err);
         }
       }
     }

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -174,7 +174,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
     }
   },
 
-  screen: async ({ device, video, viewTree }, use, testInfo) => {
+  screen: async ({ device, video, screenshot, viewTree }, use, testInfo) => {
     const videoMode = typeof video === 'object' ? video.mode : video;
     const shouldRecord = videoMode === 'on' || videoMode === 'retain-on-failure';
     const videoPath = shouldRecord
@@ -210,12 +210,26 @@ export const test = base.extend<MobilewrightTestFixtures>({
       }
     }
 
-    if (testInfo.status !== testInfo.expectedStatus) {
+    const screenshotMode = typeof screenshot === 'object' ? (screenshot as any).mode : screenshot;
+    const failed = testInfo.status !== testInfo.expectedStatus;
+    if (screenshotMode === 'on' || (screenshotMode === 'only-on-failure' && failed)) {
       try {
-        const screenshot = await device.screen.screenshot();
-        await testInfo.attach('screenshot-on-failure', { body: screenshot, contentType: 'image/png' });
+        const buf = await device.screen.screenshot();
+        const label = failed ? 'screenshot-on-failure' : 'screenshot';
+        await testInfo.attach(label, { body: buf, contentType: 'image/png' });
       } catch {
         // device may be disconnected
+      }
+    }
+
+    if (failed) {
+      if (screenshotMode !== 'on' && screenshotMode !== 'only-on-failure') {
+        try {
+          const buf = await device.screen.screenshot();
+          await testInfo.attach('screenshot-on-failure', { body: buf, contentType: 'image/png' });
+        } catch {
+          // device may be disconnected
+        }
       }
       if (viewTree === 'on-failure') {
         try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "packages/mobilewright-core" },
     { "path": "packages/driver-mobilecli" },
     { "path": "packages/driver-mobilenext" },
+    { "path": "packages/driver-saucelabs" },
     { "path": "packages/mobilewright" },
     { "path": "packages/test" }
   ]


### PR DESCRIPTION
This PR includes:
- Configuration changes to enable running end-to-end tests on Sauce Labs devices (some changes to core packages)
- New `@mobilewright/driver-saucelabs` that implements `protocol`
- The test report can now include screenshots and video when enabled for Sauce Labs.
- Unit and integration tests for the Sauce Labs driver
- Updated `e2e/mobilewright.config.ts` and `e2e/package.json` to support the new Sauce Labs driver (I need to understand how these tests are executed because I got some failures here).

Claude Code was used to generate most of the code. I reviewed the generated code and made a few adjustments.

EDIT: Docs are still missing. I can add them when we are all happy with this implementation.