### PR TITLE
fix(driver): do not fall back to accessibility name for testId identifier

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -139,7 +139,7 @@ function elementToViewNode(el: MobilecliElement): ViewNode {
   return {
     type: el.type ?? 'Unknown',
     label: el.label || undefined,
-    identifier: el.identifier || el.name || undefined,
+    identifier: el.identifier || undefined,
     value: el.value || undefined,
     text: el.text || undefined,
     placeholder: el.placeholder || undefined,

--- a/packages/driver-mobilenext/src/driver.ts
+++ b/packages/driver-mobilenext/src/driver.ts
@@ -118,7 +118,7 @@ function elementToViewNode(el: MobileNextElement): ViewNode {
   return {
     type: el.type ?? 'Unknown',
     label: el.label || undefined,
-    identifier: el.identifier || el.name || undefined,
+    identifier: el.identifier || undefined,
     value: el.value || undefined,
     text: el.text || undefined,
     placeholder: el.placeholder || undefined,


### PR DESCRIPTION
## Problem

Both drivers mapped a node's `identifier` as `el.identifier || el.name`. On iOS, `name` is the accessibility **label**, not a test identifier. This fabricated a `ViewNode.identifier` for every element with any accessibility name, so:

- The Inspector recommended `getByTestId(...)` for elements that have no real test id (e.g. a `StaticText` labelled `Your Order` showed `getByTestId('Your Order')`).
- `getByTestId('<label>')` actually matched at runtime — passing on the label rather than a real test id, and hiding the correct `getByLabel`/`getByRole` locators.

## Fix

Drop the `|| el.name` fallback in both drivers so `identifier` reflects only a real test id. `el.label` still populates `label`, so name-only elements now correctly resolve to `getByLabel` / `getByRole`.

## Note

This changes `getByTestId` semantics: any test relying on `getByTestId('<label>')` matching a label will now (correctly) fail and should switch to `getByLabel`.