### PR TITLE
feat(driver-mobilenext): allocate devices via the sessions REST API

### DIFF
--- a/packages/driver-mobilenext/src/driver.ts
+++ b/packages/driver-mobilenext/src/driver.ts
@@ -93,8 +93,6 @@ interface MobileNextDevicesResponse {
 export interface MobileNextDriverOptions {
   region?: string;
   apiKey?: string;
-  /** Timeout waiting for cloud device allocation in ms. Default: 300000 (5 min). */
-  allocationTimeout?: number;
 }
 
 const VALID_PLATFORMS = new Set<string>(['ios', 'android']);
@@ -154,36 +152,6 @@ function sanitizeFilename(name: string): string {
   return name.replace(/[^0-9a-zA-Z_.]/g, '_');
 }
 
-interface FleetAllocateResponse {
-  sessionId: string;
-  provisionId?: string;
-  state?: string;
-  device?: {
-    id: string;
-    name: string;
-    platform: string;
-    state: string;
-    model: string;
-    type: string;
-    version: string;
-  };
-}
-
-interface DevicesListDevice {
-  id: string;
-  name: string;
-  platform: string;
-  state: string;
-  model: string;
-  type: string;
-  version: string;
-  provider?: { type: string; sessionId?: string };
-}
-
-interface DevicesListResponse {
-  devices: DevicesListDevice[];
-}
-
 interface UploadCreateResponse {
   uploadId: string;
   uploadUrl: string;
@@ -193,36 +161,13 @@ interface ActiveSession {
   deviceId: string;
   platform: Platform;
   rpc: RpcClient;
-  model?: string;
-  osVersion?: string;
-  type?: DeviceType;
 }
-
-export interface MobileNextDeviceInfo {
-  model?: string;
-  osVersion?: string;
-  type?: DeviceType;
-}
-
-type DeviceFilter =
-  | { attribute: 'platform'; operator: 'EQUALS'; value: 'ios' | 'android' }
-  | { attribute: 'type'; operator: 'EQUALS'; value: 'real' }
-  | { attribute: 'name'; operator: 'EQUALS' | 'STARTS_WITH' | 'CONTAINS'; value: string }
-  | { attribute: 'version'; operator: 'EQUALS' | 'GREATER_THAN' | 'GREATER_THAN_OR_EQUALS' | 'LESS_THAN' | 'LESS_THAN_OR_EQUALS'; value: string };
 
 const debug = createDebug('mw:driver-mobilenext');
 
 export class MobileNextDriver implements MobilewrightDriver {
   private session: ActiveSession | null = null;
   private readonly options: MobileNextDriverOptions;
-  private ownsLease = false;
-
-  get deviceInfo(): MobileNextDeviceInfo | null {
-    if (!this.session) {
-      return null;
-    }
-    return { model: this.session.model, osVersion: this.session.osVersion, type: this.session.type };
-  }
 
   constructor(options: MobileNextDriverOptions = {}) {
     this.options = options;
@@ -230,115 +175,32 @@ export class MobileNextDriver implements MobilewrightDriver {
 
   // ─── Connection ──────────────────────────────────────────────
 
+  // The device must already be allocated via the fleet sessions API (see FleetApiClient); this
+  // driver only opens the RPC channel to drive it. deviceId is the physical serial the device
+  // tools accept.
   async connect(config: ConnectionConfig): Promise<Session> {
+    if (!config.deviceId) {
+      throw new Error('MobileNextDriver.connect requires a deviceId — allocate a device via the fleet sessions API first');
+    }
+
     const baseUrl = config.url ?? DEFAULT_URL;
     const url = this.options.apiKey
       ? appendQueryParam(baseUrl, 'token', this.options.apiKey)
       : baseUrl;
-    debug('connecting to %s', baseUrl);
+    debug('connecting to %s (device=%s)', baseUrl, config.deviceId);
     const rpc = new RpcClient(url, config.timeout);
     await rpc.connect();
     debug('websocket connected');
 
-    const platform = config.platform;
-
-    // When deviceId is provided the device is already allocated by the pool
-    // coordinator. Connect directly without fleet.allocate; this instance
-    // does not own the lease and must not call fleet.release on disconnect.
-    if (config.deviceId) {
-      debug('reusing pre-allocated device %s', config.deviceId);
-      this.ownsLease = false;
-      this.session = { deviceId: config.deviceId, platform, rpc };
-      return { deviceId: config.deviceId, platform };
-    }
-
-    this.ownsLease = true;
-
-    const filters = this.buildFilters(config);
-    debug('allocating device with filters %o', filters);
-    const result = await rpc.call<FleetAllocateResponse>('fleet.allocate', { filters });
-
-    let deviceId: string;
-    let model: string | undefined;
-    let osVersion: string | undefined;
-    let type: DeviceType | undefined;
-    if (result?.state === 'allocating' && result.sessionId) {
-      debug('device is provisioning, waiting for allocation (session=%s)', result.sessionId);
-      const device = await this.waitForAllocation(rpc, result.sessionId);
-      debug('allocated device %s (session=%s, model=%s)', device.id, result.sessionId, device.model);
-      deviceId = device.id;
-      model = device.model;
-      osVersion = device.version;
-      type = toDeviceType(device.type);
-    } else if (result?.device?.id) {
-      debug('allocated device %s (session=%s, model=%s)', result.device.id, result.sessionId, result.device.model);
-      deviceId = result.device.id;
-      model = result.device.model;
-      osVersion = result.device.version;
-      type = toDeviceType(result.device.type);
-    } else {
-      throw new Error(`Device allocation failed: ${JSON.stringify(result)}`);
-    }
-
-    this.session = { deviceId, platform, rpc, model, osVersion, type };
-    return { deviceId, platform };
-  }
-
-  private async waitForAllocation(
-    rpc: RpcClient,
-    sessionId: string,
-  ): Promise<DevicesListDevice> {
-    const timeout = this.options.allocationTimeout ?? 300_000;
-    const pollInterval = 5_000;
-    const deadline = Date.now() + timeout;
-
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
-      const elapsed = Math.round((timeout - (deadline - Date.now())) / 1000);
-      debug('waiting for device allocation, session=%s (%ds elapsed)', sessionId, elapsed);
-
-      const result = await rpc.call<DevicesListResponse>('devices.list', {});
-      const device = result.devices.find((d) => d.provider?.sessionId === sessionId);
-      if (!device) {
-        continue;
-      }
-      if (device.state !== 'allocating') {
-        return device;
-      }
-    }
-
-    throw new Error(`Timed out waiting for device allocation after ${timeout / 1000}s (session=${sessionId})`);
+    this.session = { deviceId: config.deviceId, platform: config.platform, rpc };
+    return { deviceId: config.deviceId, platform: config.platform };
   }
 
   async disconnect(): Promise<void> {
     const session = this.requireSession();
-    if (this.ownsLease) {
-      debug('releasing device %s', session.deviceId);
-      await session.rpc.call('fleet.release', { deviceId: session.deviceId });
-    }
     await session.rpc.disconnect();
     this.session = null;
-    this.ownsLease = false;
     debug('disconnected');
-  }
-
-  private buildFilters(config: ConnectionConfig): DeviceFilter[] {
-    const filters: DeviceFilter[] = [
-      { attribute: 'platform', operator: 'EQUALS', value: config.platform },
-    ];
-
-    if (config.deviceName) {
-      const name = typeof config.deviceName === 'string'
-        ? config.deviceName
-        : config.deviceName.source;
-      filters.push({ attribute: 'name', operator: 'CONTAINS', value: name });
-    }
-
-    if (config.osVersion) {
-      filters.push({ attribute: 'version', operator: 'EQUALS', value: config.osVersion });
-    }
-
-    return filters;
   }
 
   // ─── UI hierarchy ───────────────────────────────────────────

--- a/packages/driver-mobilenext/src/fleet-api.test.ts
+++ b/packages/driver-mobilenext/src/fleet-api.test.ts
@@ -124,6 +124,32 @@ test('releaseDevice targets the device by serial', async () => {
   expect(calls[0].path).toBe('/api/v1/sessions/sess-1/devices/SERIAL-A/release');
 });
 
+// A fetch that never resolves on its own; it only settles by rejecting when its signal aborts —
+// which is exactly how a real stalled connection behaves once the client's controller fires.
+function stallingFetch(): typeof fetch {
+  return (async (_url: string, init: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init.signal as AbortSignal;
+      signal.addEventListener('abort', () => reject(new Error('aborted')));
+    })) as unknown as typeof fetch;
+}
+
+test('a stalled request aborts and is reported as a timeout', async () => {
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn: stallingFetch(), requestTimeout: 20 });
+
+  await expect(client.createSession()).rejects.toThrow(/timed out after 20ms/);
+});
+
+test('an external abort signal cancels an in-flight allocation', async () => {
+  const controller = new AbortController();
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn: stallingFetch() });
+
+  const pending = client.allocateDevice('sess-1', [{ attribute: 'platform', operator: 'EQUALS', value: 'ios' }], controller.signal);
+  controller.abort();
+
+  await expect(pending).rejects.toThrow(/aborted/);
+});
+
 test('a failed request surfaces the API error code and message', async () => {
   const { fetchFn } = stubFetch([
     { status: 402, json: { error: { code: 'insufficient_credits', message: 'Not enough credits' } } },

--- a/packages/driver-mobilenext/src/fleet-api.test.ts
+++ b/packages/driver-mobilenext/src/fleet-api.test.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import { FleetApiClient, type SessionDevice } from './fleet-api.js';
+
+interface RecordedCall {
+  method: string;
+  path: string;
+  body: unknown;
+  authorization: string | null;
+}
+
+interface StubResponse {
+  status?: number;
+  json: unknown;
+}
+
+// A fetch stub that records every request and replays the given responses in order. The last
+// response repeats once exhausted, so pollers that call the same endpoint N times keep working.
+function stubFetch(responses: StubResponse[]): { fetchFn: typeof fetch; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  let index = 0;
+
+  const fetchFn = (async (url: string, init: RequestInit) => {
+    const headers = init.headers as Record<string, string>;
+    calls.push({
+      method: init.method ?? 'GET',
+      path: new URL(url).pathname,
+      body: init.body ? JSON.parse(init.body as string) : undefined,
+      authorization: headers?.['Authorization'] ?? null,
+    });
+    const chosen = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    const status = chosen.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => chosen.json,
+    } as Response;
+  }) as unknown as typeof fetch;
+
+  return { fetchFn, calls };
+}
+
+function readyDevice(serial: string): SessionDevice {
+  return {
+    id: 'alloc-1',
+    status: 'in_use',
+    info: { platform: 'ios', type: 'real', name: 'iPhone 15', osVersion: '17.0', serial },
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function provisioningDevice(): SessionDevice {
+  return {
+    id: 'alloc-1',
+    status: 'provisioning',
+    info: { platform: 'ios', type: 'real', name: 'iPhone 15', osVersion: '17.0' },
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+test('createSession posts to the sessions endpoint with a bearer token', async () => {
+  const { fetchFn, calls } = stubFetch([{ status: 201, json: { id: 'sess-1' } }]);
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn });
+
+  const sessionId = await client.createSession();
+
+  expect(sessionId).toBe('sess-1');
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].path).toBe('/api/v1/sessions');
+  expect(calls[0].authorization).toBe('Bearer mob_test');
+});
+
+test('allocateDevice returns immediately for a pre-booted device (serial is device.id)', async () => {
+  // The 201 response is the legacy fleet.allocate shape: the ready device lands inline under
+  // `device`, and its `id` is the physical serial the driver drives with.
+  const { fetchFn, calls } = stubFetch([
+    {
+      status: 201,
+      json: {
+        allocationId: 'alloc-1',
+        device: { id: 'SERIAL-A', name: 'iPhone 15', model: 'iPhone15,2', platform: 'ios', type: 'real', version: '17.0', state: 'online' },
+      },
+    },
+  ]);
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn });
+
+  const device = await client.allocateDevice('sess-1', [
+    { attribute: 'platform', operator: 'EQUALS', value: 'ios' },
+  ]);
+
+  expect(device.info.serial).toBe('SERIAL-A');
+  expect(device.info.osVersion).toBe('17.0');
+  // No polling was needed, so only the allocate POST happened.
+  expect(calls).toHaveLength(1);
+  expect(calls[0].path).toBe('/api/v1/sessions/sess-1/devices');
+  expect(calls[0].body).toEqual({ filters: [{ attribute: 'platform', operator: 'EQUALS', value: 'ios' }] });
+});
+
+test('allocateDevice polls the device list, matching its allocationId, until the device lands', async () => {
+  const readyB = readyDevice('SERIAL-B'); // its `id` is the allocation id the POST returned
+  const { fetchFn, calls } = stubFetch([
+    { status: 202, json: { allocationId: 'alloc-1', state: 'allocating' } }, // on-demand POST
+    { status: 200, json: { object: 'list', data: [provisioningDevice()] } }, // first poll — not ready
+    { status: 200, json: { object: 'list', data: [readyB] } }, // second poll — ready
+  ]);
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn });
+
+  const device = await client.allocateDevice('sess-1', [
+    { attribute: 'platform', operator: 'EQUALS', value: 'ios' },
+  ]);
+
+  expect(device.info.serial).toBe('SERIAL-B');
+  expect(calls[1].method).toBe('GET');
+  expect(calls[1].path).toBe('/api/v1/sessions/sess-1/devices');
+});
+
+test('releaseDevice targets the device by serial', async () => {
+  const { fetchFn, calls } = stubFetch([{ status: 202, json: readyDevice('SERIAL-A') }]);
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn });
+
+  await client.releaseDevice('sess-1', 'SERIAL-A');
+
+  expect(calls[0].method).toBe('POST');
+  expect(calls[0].path).toBe('/api/v1/sessions/sess-1/devices/SERIAL-A/release');
+});
+
+test('a failed request surfaces the API error code and message', async () => {
+  const { fetchFn } = stubFetch([
+    { status: 402, json: { error: { code: 'insufficient_credits', message: 'Not enough credits' } } },
+  ]);
+  const client = new FleetApiClient({ apiKey: 'mob_test', fetchFn });
+
+  await expect(client.createSession()).rejects.toThrow(/insufficient_credits — Not enough credits/);
+});

--- a/packages/driver-mobilenext/src/fleet-api.ts
+++ b/packages/driver-mobilenext/src/fleet-api.ts
@@ -1,0 +1,201 @@
+import createDebug from 'debug';
+
+const debug = createDebug('mw:driver-mobilenext:fleet-api');
+
+export const DEFAULT_API_URL = 'https://api.mobilenext.ai';
+
+const DEFAULT_ALLOCATION_TIMEOUT = 300_000;
+const POLL_INTERVAL = 5_000;
+
+export type DeviceStatus = 'provisioning' | 'in_use' | 'released';
+
+export interface DeviceFilter {
+  attribute: 'platform' | 'type' | 'name' | 'version';
+  operator:
+    | 'EQUALS'
+    | 'GREATER_THAN'
+    | 'GREATER_THAN_OR_EQUALS'
+    | 'LESS_THAN'
+    | 'LESS_THAN_OR_EQUALS'
+    | 'STARTS_WITH'
+    | 'CONTAINS';
+  value: string;
+}
+
+export interface SessionDevice {
+  /** Allocation id — stable and always present, including while provisioning. Not the physical id. */
+  id: string;
+  status: DeviceStatus;
+  info: {
+    platform: string;
+    type?: string;
+    name: string;
+    osVersion: string;
+    /** The physical device id (UDID/serial). Absent while provisioning; this is what device tools accept. */
+    serial?: string;
+  };
+  createdAt: string;
+  releasedAt?: string;
+}
+
+interface Session {
+  id: string;
+}
+
+interface DeviceList {
+  object: 'list';
+  data: SessionDevice[];
+}
+
+// The POST .../devices response. Despite the OpenAPI doc, the server returns the legacy
+// fleet.allocate shape, not a SessionDevice: a pre-booted device lands inline under `device`
+// (whose `id` is the physical serial), while an on-demand one returns only `allocationId` with
+// `state: "allocating"` and provisions minutes later.
+interface AllocatePostResponse {
+  allocationId: string;
+  state?: string;
+  device?: {
+    id: string;
+    name: string;
+    model?: string;
+    platform: string;
+    type?: string;
+    version?: string;
+    state?: string;
+  };
+}
+
+export interface FleetApiClientOptions {
+  apiKey: string;
+  apiUrl?: string;
+  /** Timeout waiting for a provisioning device to become in_use, in ms. Default: 300000 (5 min). */
+  allocationTimeout?: number;
+  /** Injected for testing. Defaults to the global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * REST client for the mobilefleet sessions/devices API. A session is created once per test run;
+ * each device allocation lives under that session and is addressed by its physical serial.
+ */
+export class FleetApiClient {
+  private readonly apiKey: string;
+  private readonly apiUrl: string;
+  private readonly allocationTimeout: number;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: FleetApiClientOptions) {
+    this.apiKey = options.apiKey;
+    this.apiUrl = options.apiUrl ?? DEFAULT_API_URL;
+    this.allocationTimeout = options.allocationTimeout ?? DEFAULT_ALLOCATION_TIMEOUT;
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  async createSession(): Promise<string> {
+    const session = await this.request<Session>('POST', '/api/v1/sessions');
+    debug('created session %s', session.id);
+    return session.id;
+  }
+
+  /**
+   * Allocates a device into the session and waits until it is in_use (has a serial). A pre-booted
+   * device is ready immediately; an on-demand one provisions for minutes before landing.
+   */
+  async allocateDevice(sessionId: string, filters: DeviceFilter[]): Promise<SessionDevice> {
+    const path = `/api/v1/sessions/${encodeURIComponent(sessionId)}/devices`;
+    const res = await this.request<AllocatePostResponse>('POST', path, { filters });
+    debug('allocate accepted (allocationId=%s, state=%s)', res.allocationId, res.state ?? (res.device ? 'ready' : 'unknown'));
+
+    // Pre-booted device: it is ready inline and its `id` is the physical serial.
+    if (res.device?.id) {
+      return {
+        id: res.allocationId,
+        status: 'in_use',
+        info: {
+          platform: res.device.platform,
+          type: res.device.type,
+          name: res.device.name,
+          osVersion: res.device.version ?? '',
+          serial: res.device.id,
+        },
+        createdAt: '',
+      };
+    }
+
+    if (!res.allocationId) {
+      throw new Error(`Allocate response missing allocationId: ${JSON.stringify(res)}`);
+    }
+    // On-demand device: poll the session's device list until this allocation lands with a serial.
+    return this.waitForDevice(sessionId, res.allocationId);
+  }
+
+  /** Releases a device back to the pool. Addressed by serial, the same id device tools accept. */
+  async releaseDevice(sessionId: string, serial: string): Promise<void> {
+    const path = `/api/v1/sessions/${encodeURIComponent(sessionId)}/devices/${encodeURIComponent(serial)}/release`;
+    await this.request('POST', path);
+    debug('released device %s', serial);
+  }
+
+  // A provisioning device has no serial, and GET .../devices/{id} matches on serial — so the only
+  // way to watch a still-provisioning allocation is to list the session's devices and match by
+  // allocation id until it transitions to in_use.
+  private async waitForDevice(sessionId: string, allocationId: string): Promise<SessionDevice> {
+    const deadline = Date.now() + this.allocationTimeout;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+      const list = await this.request<DeviceList>('GET', `/api/v1/sessions/${encodeURIComponent(sessionId)}/devices`);
+      const device = list.data.find((d) => d.id === allocationId);
+      if (!device) {
+        continue;
+      }
+      debug('waiting for device (allocationId=%s, status=%s)', allocationId, device.status);
+      if (device.status === 'in_use' && device.info.serial) {
+        return device;
+      }
+      if (device.status === 'released') {
+        throw new Error(`Device allocation ${allocationId} was released before becoming ready`);
+      }
+    }
+    throw new Error(
+      `Timed out waiting for device allocation after ${this.allocationTimeout / 1000}s (session=${sessionId}, allocation=${allocationId})`,
+    );
+  }
+
+  private async request<T = void>(method: string, path: string, body?: unknown): Promise<T> {
+    const headers: Record<string, string> = { 'Authorization': `Bearer ${this.apiKey}` };
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const res = await this.fetchFn(`${this.apiUrl}${path}`, {
+      method,
+      headers,
+      ...(body !== undefined && { body: JSON.stringify(body) }),
+    });
+
+    if (!res.ok) {
+      const detail = await this.errorDetail(res);
+      throw new Error(`${method} ${path} failed with ${res.status}${detail ? `: ${detail}` : ''}`);
+    }
+    if (res.status === 204) {
+      debug('%s %s -> %d (no content)', method, path, res.status);
+      return undefined as T;
+    }
+    const result = (await res.json()) as T;
+    debug('%s %s -> %d %o', method, path, res.status, result);
+    return result;
+  }
+
+  // The API's error body is {error: {code, message}}; surface both so callers see actionable text.
+  private async errorDetail(res: Response): Promise<string> {
+    try {
+      const body = (await res.json()) as { error?: { code?: string; message?: string } };
+      if (body?.error?.message) {
+        return body.error.code ? `${body.error.code} — ${body.error.message}` : body.error.message;
+      }
+    } catch {
+      // non-JSON body — nothing to add
+    }
+    return '';
+  }
+}

--- a/packages/driver-mobilenext/src/fleet-api.ts
+++ b/packages/driver-mobilenext/src/fleet-api.ts
@@ -5,6 +5,7 @@ const debug = createDebug('mw:driver-mobilenext:fleet-api');
 export const DEFAULT_API_URL = 'https://api.mobilenext.ai';
 
 const DEFAULT_ALLOCATION_TIMEOUT = 300_000;
+const DEFAULT_REQUEST_TIMEOUT = 30_000;
 const POLL_INTERVAL = 5_000;
 
 export type DeviceStatus = 'provisioning' | 'in_use' | 'released';
@@ -70,8 +71,30 @@ export interface FleetApiClientOptions {
   apiUrl?: string;
   /** Timeout waiting for a provisioning device to become in_use, in ms. Default: 300000 (5 min). */
   allocationTimeout?: number;
+  /** Timeout for a single HTTP request, in ms. Bounds a stalled fetch. Default: 30000. */
+  requestTimeout?: number;
   /** Injected for testing. Defaults to the global fetch. */
   fetchFn?: typeof fetch;
+}
+
+// A setTimeout that rejects when the signal aborts, so a mid-poll shutdown/timeout is not held up
+// for the full interval.
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('aborted'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error('aborted'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 /**
@@ -82,12 +105,14 @@ export class FleetApiClient {
   private readonly apiKey: string;
   private readonly apiUrl: string;
   private readonly allocationTimeout: number;
+  private readonly requestTimeout: number;
   private readonly fetchFn: typeof fetch;
 
   constructor(options: FleetApiClientOptions) {
     this.apiKey = options.apiKey;
     this.apiUrl = options.apiUrl ?? DEFAULT_API_URL;
     this.allocationTimeout = options.allocationTimeout ?? DEFAULT_ALLOCATION_TIMEOUT;
+    this.requestTimeout = options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT;
     this.fetchFn = options.fetchFn ?? fetch;
   }
 
@@ -101,9 +126,9 @@ export class FleetApiClient {
    * Allocates a device into the session and waits until it is in_use (has a serial). A pre-booted
    * device is ready immediately; an on-demand one provisions for minutes before landing.
    */
-  async allocateDevice(sessionId: string, filters: DeviceFilter[]): Promise<SessionDevice> {
+  async allocateDevice(sessionId: string, filters: DeviceFilter[], signal?: AbortSignal): Promise<SessionDevice> {
     const path = `/api/v1/sessions/${encodeURIComponent(sessionId)}/devices`;
-    const res = await this.request<AllocatePostResponse>('POST', path, { filters });
+    const res = await this.request<AllocatePostResponse>('POST', path, { filters }, signal);
     debug('allocate accepted (allocationId=%s, state=%s)', res.allocationId, res.state ?? (res.device ? 'ready' : 'unknown'));
 
     // Pre-booted device: it is ready inline and its `id` is the physical serial.
@@ -126,7 +151,7 @@ export class FleetApiClient {
       throw new Error(`Allocate response missing allocationId: ${JSON.stringify(res)}`);
     }
     // On-demand device: poll the session's device list until this allocation lands with a serial.
-    return this.waitForDevice(sessionId, res.allocationId);
+    return this.waitForDevice(sessionId, res.allocationId, signal);
   }
 
   /** Releases a device back to the pool. Addressed by serial, the same id device tools accept. */
@@ -139,11 +164,11 @@ export class FleetApiClient {
   // A provisioning device has no serial, and GET .../devices/{id} matches on serial — so the only
   // way to watch a still-provisioning allocation is to list the session's devices and match by
   // allocation id until it transitions to in_use.
-  private async waitForDevice(sessionId: string, allocationId: string): Promise<SessionDevice> {
+  private async waitForDevice(sessionId: string, allocationId: string, signal?: AbortSignal): Promise<SessionDevice> {
     const deadline = Date.now() + this.allocationTimeout;
     while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
-      const list = await this.request<DeviceList>('GET', `/api/v1/sessions/${encodeURIComponent(sessionId)}/devices`);
+      await delay(POLL_INTERVAL, signal);
+      const list = await this.request<DeviceList>('GET', `/api/v1/sessions/${encodeURIComponent(sessionId)}/devices`, undefined, signal);
       const device = list.data.find((d) => d.id === allocationId);
       if (!device) {
         continue;
@@ -161,29 +186,57 @@ export class FleetApiClient {
     );
   }
 
-  private async request<T = void>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T = void>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
     const headers: Record<string, string> = { 'Authorization': `Bearer ${this.apiKey}` };
     if (body !== undefined) {
       headers['Content-Type'] = 'application/json';
     }
 
-    const res = await this.fetchFn(`${this.apiUrl}${path}`, {
-      method,
-      headers,
-      ...(body !== undefined && { body: JSON.stringify(body) }),
-    });
+    // Bound the call: a private controller fires on requestTimeout, and an external signal (pool
+    // shutdown/allocation timeout) is forwarded into it so a stalled fetch aborts either way. The
+    // controller covers body reading too, so a response whose body stalls is bounded as well.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.requestTimeout);
+    const onExternalAbort = () => controller.abort();
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort();
+      } else {
+        signal.addEventListener('abort', onExternalAbort, { once: true });
+      }
+    }
 
-    if (!res.ok) {
-      const detail = await this.errorDetail(res);
-      throw new Error(`${method} ${path} failed with ${res.status}${detail ? `: ${detail}` : ''}`);
+    try {
+      const res = await this.fetchFn(`${this.apiUrl}${path}`, {
+        method,
+        headers,
+        signal: controller.signal,
+        ...(body !== undefined && { body: JSON.stringify(body) }),
+      });
+
+      if (!res.ok) {
+        const detail = await this.errorDetail(res);
+        throw new Error(`${method} ${path} failed with ${res.status}${detail ? `: ${detail}` : ''}`);
+      }
+      if (res.status === 204) {
+        debug('%s %s -> %d (no content)', method, path, res.status);
+        return undefined as T;
+      }
+      const result = (await res.json()) as T;
+      debug('%s %s -> %d %o', method, path, res.status, result);
+      return result;
+    } catch (err) {
+      if (signal?.aborted) {
+        throw new Error(`${method} ${path} aborted`);
+      }
+      if (controller.signal.aborted) {
+        throw new Error(`${method} ${path} timed out after ${this.requestTimeout}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onExternalAbort);
     }
-    if (res.status === 204) {
-      debug('%s %s -> %d (no content)', method, path, res.status);
-      return undefined as T;
-    }
-    const result = (await res.json()) as T;
-    debug('%s %s -> %d %o', method, path, res.status, result);
-    return result;
   }
 
   // The API's error body is {error: {code, message}}; surface both so callers see actionable text.

--- a/packages/driver-mobilenext/src/index.ts
+++ b/packages/driver-mobilenext/src/index.ts
@@ -1,4 +1,12 @@
-export { MobileNextDriver, DEFAULT_URL, type MobileNextDriverOptions, type MobileNextDeviceInfo } from './driver.js';
+export { MobileNextDriver, DEFAULT_URL, type MobileNextDriverOptions } from './driver.js';
 export { RpcClient } from './rpc-client.js';
+export {
+  FleetApiClient,
+  DEFAULT_API_URL,
+  type FleetApiClientOptions,
+  type SessionDevice,
+  type DeviceFilter,
+  type DeviceStatus,
+} from './fleet-api.js';
 export { uploadTestResult, extractGitInfoFromReport, type UploadTestResultParams, type GitInfo } from './upload-client.js';
 export { default as MobileNextUploadReporter, type MobileNextTestResultConfig } from './reporter.js';

--- a/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.test.ts
+++ b/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import type { FleetApiClient, SessionDevice } from '@mobilewright/driver-mobilenext';
+import { MobileNextAllocator } from './mobilenext-allocator.js';
+
+function readyDevice(serial: string): SessionDevice {
+  return {
+    id: 'alloc-1',
+    status: 'in_use',
+    info: { platform: 'ios', type: 'real', name: 'iPhone 15', osVersion: '17.0', serial },
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+// Builds an allocator over a fake FleetApiClient whose createSession behaviour the test controls.
+function allocatorWithSession(createSession: () => Promise<string>): MobileNextAllocator {
+  const client = {
+    createSession,
+    allocateDevice: async () => readyDevice('SERIAL-A'),
+    releaseDevice: async () => {},
+  } as unknown as FleetApiClient;
+  return new MobileNextAllocator({ apiKey: 'mob_test', client });
+}
+
+test('allocate throws when no platform is given instead of silently defaulting to iOS', async () => {
+  const allocator = allocatorWithSession(async () => 'sess-1');
+
+  await expect(allocator.allocate({}, new Set())).rejects.toThrow(/requires a platform/);
+});
+
+test('a failed session creation can be retried by a later allocate', async () => {
+  let attempts = 0;
+  const allocator = allocatorWithSession(async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw new Error('session boom');
+    }
+    return 'sess-1';
+  });
+
+  await expect(allocator.allocate({ platform: 'ios' }, new Set())).rejects.toThrow(/session boom/);
+
+  const result = await allocator.allocate({ platform: 'ios' }, new Set());
+  expect(result.deviceId).toBe('SERIAL-A');
+  expect(attempts).toBe(2);
+});

--- a/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.test.ts
+++ b/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.test.ts
@@ -27,6 +27,12 @@ test('allocate throws when no platform is given instead of silently defaulting t
   await expect(allocator.allocate({}, new Set())).rejects.toThrow(/requires a platform/);
 });
 
+test('allocate rejects a pinned deviceId instead of silently allocating a different device', async () => {
+  const allocator = allocatorWithSession(async () => 'sess-1');
+
+  await expect(allocator.allocate({ platform: 'ios', deviceId: 'UDID-123' }, new Set())).rejects.toThrow(/cannot pin a specific deviceId/);
+});
+
 test('a failed session creation can be retried by a later allocate', async () => {
   let attempts = 0;
   const allocator = allocatorWithSession(async () => {

--- a/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.ts
+++ b/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.ts
@@ -13,8 +13,13 @@ function toDeviceType(value?: string): DeviceType | undefined {
 }
 
 function buildFilters(criteria: AllocationCriteria): DeviceFilter[] {
+  // The fleet API requires exactly one platform filter, so a missing platform is a caller error —
+  // fail loudly instead of silently constraining every allocation to iOS.
+  if (!criteria.platform) {
+    throw new Error('MobileNextAllocator requires a platform ("ios" or "android") to allocate a device');
+  }
   const filters: DeviceFilter[] = [
-    { attribute: 'platform', operator: 'EQUALS', value: criteria.platform ?? 'ios' },
+    { attribute: 'platform', operator: 'EQUALS', value: criteria.platform },
   ];
   if (criteria.deviceNamePattern) {
     filters.push({ attribute: 'name', operator: 'CONTAINS', value: criteria.deviceNamePattern });
@@ -49,12 +54,20 @@ export class MobileNextAllocator implements DeviceAllocator {
     });
   }
 
-  async allocate(criteria: AllocationCriteria): Promise<AllocateResult> {
-    const sessionId = await this.getSession();
+  // takenDeviceIds is unused: the fleet allocates a fresh device server-side per call and the
+  // filter DSL has no "exclude id" operator, so the pool's local set is both redundant and
+  // inexpressible here. signal is threaded through so a pool shutdown or allocation timeout
+  // cancels an in-flight provisioning wait.
+  async allocate(
+    criteria: AllocationCriteria,
+    takenDeviceIds: ReadonlySet<string>,
+    signal?: AbortSignal,
+  ): Promise<AllocateResult> {
     const filters = buildFilters(criteria);
+    const sessionId = await this.getSession();
     debug('allocating device (session=%s, filters=%o)', sessionId, filters);
 
-    const device = await this.client.allocateDevice(sessionId, filters);
+    const device = await this.client.allocateDevice(sessionId, filters, signal);
     const serial = device.info.serial;
     if (!serial) {
       throw new Error(`Device allocation ${device.id} became in_use without a serial`);
@@ -84,9 +97,13 @@ export class MobileNextAllocator implements DeviceAllocator {
   }
 
   // Cache the promise, not the id, so concurrent first allocations share a single createSession.
+  // On failure, clear the cache so a later allocate() can retry instead of inheriting the rejection.
   private getSession(): Promise<string> {
     if (!this.sessionPromise) {
-      this.sessionPromise = this.client.createSession();
+      this.sessionPromise = this.client.createSession().catch((err: unknown) => {
+        this.sessionPromise = null;
+        throw err;
+      });
     }
     return this.sessionPromise;
   }

--- a/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.ts
+++ b/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.ts
@@ -1,43 +1,93 @@
 import createDebug from 'debug';
-import { MobileNextDriver } from '@mobilewright/driver-mobilenext';
-import type { MobileNextDriverOptions } from '@mobilewright/driver-mobilenext';
+import { FleetApiClient } from '@mobilewright/driver-mobilenext';
+import type { DeviceFilter } from '@mobilewright/driver-mobilenext';
+import type { DeviceType, Platform } from '@mobilewright/protocol';
 import type { AllocationCriteria, AllocateResult, DeviceAllocator } from '../application/ports.js';
 
 const debug = createDebug('mw:device-pool:mobilenext');
 
-export interface MobileNextAllocatorOptions {
-  driverOptions: MobileNextDriverOptions;
+const VALID_DEVICE_TYPES = new Set<string>(['real', 'simulator', 'emulator']);
+
+function toDeviceType(value?: string): DeviceType | undefined {
+  return value && VALID_DEVICE_TYPES.has(value) ? (value as DeviceType) : undefined;
 }
 
+function buildFilters(criteria: AllocationCriteria): DeviceFilter[] {
+  const filters: DeviceFilter[] = [
+    { attribute: 'platform', operator: 'EQUALS', value: criteria.platform ?? 'ios' },
+  ];
+  if (criteria.deviceNamePattern) {
+    filters.push({ attribute: 'name', operator: 'CONTAINS', value: criteria.deviceNamePattern });
+  }
+  return filters;
+}
+
+export interface MobileNextAllocatorOptions {
+  apiKey: string;
+  apiUrl?: string;
+  allocationTimeout?: number;
+  /** Injected for testing. */
+  client?: FleetApiClient;
+}
+
+/**
+ * Allocates devices through the fleet sessions REST API. One session is created per test run
+ * (lazily, on first allocation) and every device allocation lives under it. A device is addressed
+ * by its physical serial, which is also the id the RPC driver drives with.
+ */
 export class MobileNextAllocator implements DeviceAllocator {
-  private readonly driverOptions: MobileNextDriverOptions;
-  private readonly activeDrivers = new Map<string, MobileNextDriver>();
+  private readonly client: FleetApiClient;
+  private sessionPromise: Promise<string> | null = null;
+  // serial -> the session it was allocated in, needed to release it later.
+  private readonly sessionBySerial = new Map<string, string>();
 
   constructor(options: MobileNextAllocatorOptions) {
-    this.driverOptions = options.driverOptions;
+    this.client = options.client ?? new FleetApiClient({
+      apiKey: options.apiKey,
+      apiUrl: options.apiUrl,
+      allocationTimeout: options.allocationTimeout,
+    });
   }
 
   async allocate(criteria: AllocationCriteria): Promise<AllocateResult> {
-    debug('allocating device (criteria=%o)', criteria);
-    const driver = new MobileNextDriver(this.driverOptions);
-    const session = await driver.connect({
-      platform: criteria.platform ?? 'ios',
-      deviceName: criteria.deviceNamePattern ? new RegExp(criteria.deviceNamePattern) : undefined,
-      deviceId: criteria.deviceId,
-    });
-    this.activeDrivers.set(session.deviceId, driver);
-    debug('allocated device %s (platform=%s)', session.deviceId, session.platform);
-    const info = driver.deviceInfo;
-    return { deviceId: session.deviceId, platform: session.platform, driver: 'mobilenext', model: info?.model, osVersion: info?.osVersion, type: info?.type };
+    const sessionId = await this.getSession();
+    const filters = buildFilters(criteria);
+    debug('allocating device (session=%s, filters=%o)', sessionId, filters);
+
+    const device = await this.client.allocateDevice(sessionId, filters);
+    const serial = device.info.serial;
+    if (!serial) {
+      throw new Error(`Device allocation ${device.id} became in_use without a serial`);
+    }
+    this.sessionBySerial.set(serial, sessionId);
+    debug('allocated device %s (allocation=%s, platform=%s)', serial, device.id, device.info.platform);
+
+    return {
+      deviceId: serial,
+      platform: device.info.platform === 'android' ? 'android' : ('ios' as Platform),
+      driver: 'mobilenext',
+      model: device.info.name,
+      osVersion: device.info.osVersion,
+      type: toDeviceType(device.info.type),
+    };
   }
 
   async release(deviceId: string): Promise<void> {
-    debug('releasing device %s', deviceId);
-    const driver = this.activeDrivers.get(deviceId);
-    if (driver) {
-      this.activeDrivers.delete(deviceId);
-      await driver.disconnect();
-      debug('released device %s', deviceId);
+    const sessionId = this.sessionBySerial.get(deviceId);
+    if (!sessionId) {
+      return;
     }
+    this.sessionBySerial.delete(deviceId);
+    debug('releasing device %s (session=%s)', deviceId, sessionId);
+    await this.client.releaseDevice(sessionId, deviceId);
+    debug('released device %s', deviceId);
+  }
+
+  // Cache the promise, not the id, so concurrent first allocations share a single createSession.
+  private getSession(): Promise<string> {
+    if (!this.sessionPromise) {
+      this.sessionPromise = this.client.createSession();
+    }
+    return this.sessionPromise;
   }
 }

--- a/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.ts
+++ b/packages/mobilewright/src/device-pool/adapters/mobilenext-allocator.ts
@@ -18,6 +18,14 @@ function buildFilters(criteria: AllocationCriteria): DeviceFilter[] {
   if (!criteria.platform) {
     throw new Error('MobileNextAllocator requires a platform ("ios" or "android") to allocate a device');
   }
+  // The fleet filter DSL has no exact-device selector (only platform/type/name/version), so a
+  // pinned deviceId cannot be honored. Reject it rather than silently allocating a different
+  // device — deviceId is for local drivers; select a cloud device by deviceName instead.
+  if (criteria.deviceId) {
+    throw new Error(
+      `MobileNextAllocator cannot pin a specific deviceId ("${criteria.deviceId}"): the fleet does not support exact-device selection. Remove deviceId or filter by deviceName.`,
+    );
+  }
   const filters: DeviceFilter[] = [
     { attribute: 'platform', operator: 'EQUALS', value: criteria.platform },
   ];

--- a/packages/mobilewright/src/device-pool/allocator-factory.ts
+++ b/packages/mobilewright/src/device-pool/allocator-factory.ts
@@ -23,10 +23,8 @@ export async function createAllocator(config: MobilewrightConfig): Promise<Alloc
   if (driverType === 'mobilenext' || driverType === 'mobile-use') {
     const mobileNextConfig = config.driver as DriverConfigMobileNext;
     const allocator = new MobileNextAllocator({
-      driverOptions: {
-        region: mobileNextConfig.region,
-        apiKey: mobileNextConfig.apiKey,
-      },
+      apiKey: mobileNextConfig.apiKey ?? '',
+      allocationTimeout: mobileNextConfig.allocationTimeout,
     });
     return { allocator };
   }

--- a/packages/mobilewright/src/launchers.ts
+++ b/packages/mobilewright/src/launchers.ts
@@ -55,7 +55,6 @@ export function createDriver(driverConfig?: DriverConfig, url?: string): Mobilew
     return new MobileNextDriver({
       region: driverConfig.region,
       apiKey: driverConfig.apiKey,
-      allocationTimeout: driverConfig.allocationTimeout,
     });
   }
   return new MobilecliDriver({ url });


### PR DESCRIPTION
## What

Moves cloud device allocation off the `fleet.allocate` WebSocket RPC and onto the mobilefleet **sessions REST API**, reflecting the server-side change where a single session can hold multiple device allocations.

## Flow

- `POST /api/v1/sessions` → one session per test run (created lazily on first allocation, shared across parallel workers).
- `POST /api/v1/sessions/{sessionId}/devices` `{ filters }` → returns an **allocationId** (the device allocation id, distinct from the session id).
  - Pre-booted device: `201 { allocationId, device: { id: <serial>, … } }` — ready inline.
  - On-demand device: `202 { allocationId, state: "allocating" }` — provisions asynchronously.
- Poll `GET /api/v1/sessions/{sessionId}/devices`, matching the list entry by `id === allocationId`, until `status: "in_use"` with an `info.serial`.
- Drive/release the device by its **serial** (`POST .../devices/{serial}/release`).

Matching by allocationId (not "the first in_use device") is required because a shared session lists several devices at once — it keeps parallel workers from picking up each other's devices.

## Changes

- **`driver-mobilenext`**
  - New `FleetApiClient` (REST): `createSession`, `allocateDevice` (with provisioning poll), `releaseDevice`. Bearer `mob_` auth, base `https://api.mobilenext.ai`. Debug-gated per-call body logging under `mw:driver-mobilenext:fleet-api`.
  - `MobileNextDriver` no longer allocates — `connect()` only opens the RPC channel to drive a pre-allocated serial (dead `fleet.allocate`/`waitForAllocation`/`fleet.release` path removed).
- **`mobilewright` device-pool**
  - `MobileNextAllocator` rewritten to use `FleetApiClient` (session per run, allocation per `allocate()`, release by serial).
  - `allocator-factory` / `launchers` updated to the new options shape; `allocationTimeout` now correctly reaches the poller (previously silently dropped in the pool path).

## Test plan

- [x] `npm run lint` (tsc + eslint) passes
- [x] New `fleet-api.test.ts`: session create, pre-booted allocate, provisioning poll-by-allocationId, release-by-serial, API error surfacing
- [x] Existing device-pool + driver tests pass
- [x] Verified end-to-end against a live iOS run (`npx mobilewright test`)