### PR TITLE
docs: add Actions and Configuration guides

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -17,6 +17,7 @@ const sidebars = {
       label: 'Mobilewright Test',
       collapsed: false,
       items: [
+        'test/configuration',
         'test/cli',
         'test/fixtures',
         'test/parallelism',
@@ -31,6 +32,7 @@ const sidebars = {
       label: 'Guides',
       collapsed: false,
       items: [
+        'guides/actions',
         'guides/assertions',
         'guides/auto-waiting',
         'guides/deep-links',

--- a/docs/src/guides/actions.md
+++ b/docs/src/guides/actions.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 1
+title: Actions
+---
+
+# Actions
+
+Actions are how your test drives the app: tapping, typing, swiping, pressing hardware buttons. Mobilewright exposes them in two places:
+
+- **On a locator** — `screen.getByText('Sign In').tap()`. The locator resolves the element, [auto-waits](./auto-waiting.md) until it's actionable, then acts on its center. This is what you want almost all the time.
+- **On the screen** — `screen.tap(200, 400)`. These take raw coordinates and do **not** auto-wait. Reach for them only when there's no element to target (a canvas, a game surface) or when driving hardware buttons and gestures.
+
+## Locator actions
+
+Every locator action accepts a `timeout` (in ms) that overrides the configured [action timeout](../test/timeouts.md) for that one call.
+
+### Tap
+
+```ts
+await screen.getByRole('button', { name: 'Submit' }).tap();
+await screen.getByText('Options').tap({ timeout: 10_000 });
+```
+
+### Double tap and long press
+
+```ts
+await screen.getByText('Photo').doubleTap();
+await screen.getByText('Message').longPress();
+await screen.getByText('Message').longPress({ duration: 1_500 });
+```
+
+`longPress` accepts an optional `duration` in milliseconds. Omit it to use the driver default.
+
+### Fill and clear
+
+`fill` focuses the field, clears any existing text, then types the new value. Use `clear` on its own to empty a field without typing.
+
+```ts
+await screen.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+await screen.getByRole('textbox', { name: 'Email' }).clear();
+```
+
+`fill` clears first, so you don't need to call `clear` before it. If the field can't be emptied, `fill` and `clear` throw rather than silently appending to leftover text.
+
+### Swipe
+
+Swipe in a direction starting from the element's center. `direction` is required.
+
+```ts
+await screen.getByText('Card').swipe({ direction: 'left' });
+```
+
+Direction is one of `'up'`, `'down'`, `'left'`, `'right'`.
+
+### Scroll into view
+
+Swipe repeatedly until the element enters the viewport, then stop. Useful before acting on something below the fold.
+
+```ts
+await screen.getByText('Delete account').scrollIntoViewIfNeeded();
+await screen.getByText('Delete account').tap();
+```
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `maxSwipes` | `10` | Give up after this many swipe attempts |
+| `direction` | `'up'` | Swipe direction while searching — `'up'` scrolls content down, `'down'` scrolls content up |
+
+## Screen actions
+
+These act on raw coordinates or the device itself. They don't resolve or wait for any element.
+
+### Coordinate taps
+
+```ts
+await screen.tap(200, 400);
+await screen.doubleTap(200, 400);
+await screen.longPress(200, 400, 1_500); // optional duration in ms
+```
+
+### Swipe
+
+Swipe across the screen. Defaults to starting at the screen center and covering half the relevant dimension.
+
+```ts
+await screen.swipe('up');
+await screen.swipe('down', { distance: 300 });
+await screen.swipe('left', { startX: 300, startY: 500, duration: 400 });
+```
+
+| Option | Description |
+| --- | --- |
+| `distance` | Swipe distance in points (default: 50% of the screen dimension) |
+| `duration` | Swipe duration in ms |
+| `startX`, `startY` | Starting point (default: center of screen) |
+
+### Hardware buttons
+
+```ts
+await screen.pressButton('HOME');
+await screen.goBack(); // Android — shorthand for pressButton('BACK')
+```
+
+Available buttons: `HOME`, `BACK`, `POWER`, `VOLUME_UP`, `VOLUME_DOWN`, `ENTER`, `DPAD_UP`, `DPAD_DOWN`, `DPAD_LEFT`, `DPAD_RIGHT`, `DPAD_CENTER`, `APP_SWITCH`, `LOCK`.
+
+### Custom gestures
+
+For multi-touch or precisely-timed paths, `gesture` takes one or more pointer paths. Each pointer is an array of points; `time` is the offset in ms from the start of the gesture.
+
+```ts
+// Pinch to zoom out — two fingers moving toward each other
+await screen.gesture({
+  pointers: [
+    [{ x: 100, y: 400, time: 0 }, { x: 200, y: 400, time: 300 }],
+    [{ x: 500, y: 400, time: 0 }, { x: 400, y: 400, time: 300 }],
+  ],
+});
+```
+
+## Which to use
+
+Prefer locator actions. They auto-wait, so tests stay stable when the UI is still loading or animating, and they read as intent (`getByText('Sign In').tap()`) rather than magic numbers. Drop to screen actions only when there's genuinely no element to target, or for device-level input like hardware buttons and gestures.

--- a/docs/src/test/configuration.md
+++ b/docs/src/test/configuration.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 1
+title: Configuration
+---
+
+# Configuration
+
+Mobilewright is configured through a `mobilewright.config.ts` file at the root of your project. Wrap the object in `defineConfig` for type-checking and editor autocomplete.
+
+```ts
+import { defineConfig } from 'mobilewright';
+
+export default defineConfig({
+  platform: 'ios',
+  bundleId: 'com.example.myapp',
+  deviceName: /iPhone/,
+  timeout: 30_000,
+});
+```
+
+## Config file resolution
+
+When you run `mobilewright test`, it looks for these files in the current directory, in order:
+
+1. `mobilewright.config.ts`
+2. `mobilewright.config.js`
+3. `mobilewright.config.mjs`
+
+Pass `--config <path>` to point at a specific file instead. If no config is found, Mobilewright runs with defaults.
+
+## Device and app
+
+Which device to run on and which app to drive.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `platform` | `'ios' \| 'android'` | — | Target platform |
+| `deviceId` | `string` | — | Specific device identifier (local drivers only) |
+| `deviceName` | `RegExp` | — | Match a device by name, e.g. `/iPhone 17/` |
+| `bundleId` | `string` | — | App bundle ID to launch |
+| `installApps` | `string \| string[]` | — | App paths (APK/IPA) to install before launching |
+| `autoAppLaunch` | `boolean` | `true` | Launch the app automatically after connecting |
+
+## Driver
+
+The driver decides where tests run — a local device via mobilecli, or a cloud device.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `driver` | `DriverConfig` | `{ type: 'mobilecli' }` | Which driver to use (see below) |
+| `url` | `string` | — | mobilecli server URL (for a remote server) |
+| `mobilecliPath` | `string` | — | Path to the mobilecli binary if it's not on `PATH` |
+| `autoStart` | `boolean` | `true` | Auto-start the mobilecli server if it isn't running |
+
+**Local (mobilecli):**
+
+```ts
+driver: { type: 'mobilecli' }
+```
+
+**Cloud (Mobile Next):**
+
+```ts
+driver: {
+  type: 'mobilenext',
+  apiKey: process.env.MOBILENEXT_API_KEY,
+  region: 'us',
+  allocationTimeout: 300_000, // wait for a cloud device, ms (default: 5 min)
+  uploadTimeout: 60_000,      // upload test results, ms (default: none)
+}
+```
+
+With the `mobilenext` driver, test results are uploaded to mobilenext.ai automatically unless you set `testResult: { uploadReport: 'off' }`.
+
+## Test runner
+
+How tests are discovered and executed.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `testDir` | `string` | config file dir | Directory to search for tests |
+| `testMatch` | `string \| RegExp \| Array` | `**/*.{test,spec}.{js,ts,mjs}` | Glob patterns for test files |
+| `testIgnore` | `string \| RegExp \| Array` | — | Patterns to skip during discovery |
+| `outputDir` | `string` | `test-results` | Directory for test artifacts |
+| `timeout` | `number` | — | Per-test timeout in ms |
+| `globalTimeout` | `number` | — | Hard cap on the entire suite run in ms |
+| `retries` | `number` | — | Max retries for flaky tests — see [Retries](./retries.md) |
+| `workers` | `number \| string` | `1` | Concurrent workers — see [Parallelism](./parallelism.md) |
+| `fullyParallel` | `boolean` | `false` | Run all tests in parallel |
+| `forbidOnly` | `boolean` | — | Fail the run if `test.only` is present (useful in CI) |
+| `reporter` | `'list' \| 'html' \| 'json' \| 'junit' \| Array` | — | Reporter(s) to use |
+| `globalSetup` | `string \| string[]` | — | File(s) run once before all tests |
+| `globalTeardown` | `string \| string[]` | — | File(s) run once after all tests |
+| `projects` | `ProjectConfig[]` | — | Multi-device / multi-platform matrix — see [Projects](./projects.md) |
+
+## Timeouts and per-action defaults
+
+`use` sets defaults applied to every test. `expect` sets the default assertion timeout. Both can be overridden per project and per call.
+
+```ts
+export default defineConfig({
+  use: {
+    actionTimeout: 5_000,     // tap, fill, etc. — default 5000
+    appLaunchTimeout: 20_000, // wait for app foreground — default 20000
+    installTimeout: 120_000,  // installApps — default none
+    animations: 'off',        // system animations: 'on' | 'off'
+  },
+  expect: {
+    timeout: 5_000, // toBeVisible, toHaveText, etc. — default 5000
+  },
+});
+```
+
+See [Timeouts](./timeouts.md) for how these interact and how to override them at call sites.
+
+## Reporting
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `viewTree` | `'on-failure' \| 'off'` | `'off'` | Attach the accessibility tree as JSON to the report; `'on-failure'` attaches only on failing tests |
+| `captureGitInfo` | `{ commit?: boolean; diff?: boolean }` | — | Capture git commit info into report metadata |
+
+## Per-project overrides
+
+Everything that varies by device belongs in `projects`. Each project has a `use` block that overrides the top-level settings for that run.
+
+```ts
+export default defineConfig({
+  bundleId: 'com.example.myapp',
+  projects: [
+    { name: 'iOS', use: { platform: 'ios', deviceName: /iPhone/ } },
+    { name: 'Android', use: { platform: 'android', deviceName: /Pixel/ } },
+  ],
+});
+```
+
+The project `use` block accepts `platform`, `deviceName`, `bundleId`, `installApps`, `animations`, `actionTimeout`, `appLaunchTimeout`, and `installTimeout`. Projects can also override `timeout`, `testDir`, `testMatch`, `testIgnore`, `outputDir`, `retries`, `grep`, `grepInvert`, and declare `dependencies` on other projects. See [Projects](./projects.md) for the full matrix.


### PR DESCRIPTION
Adds two new documentation pages, both derived directly from source (`config.ts`, `locator.ts`, `screen.ts`, `protocol/types.ts`).

## Actions (`guides/actions.md`)
Consolidates the input API that was previously only shown incidentally in examples:
- Locator vs screen actions and when to use each
- Locator: `tap`, `doubleTap`, `longPress`, `fill`/`clear`, `swipe`, `scrollIntoViewIfNeeded` with real options
- Screen: coordinate taps, `swipe` (+`SwipeOptions`), `pressButton` (full hardware-button list), `goBack`, `gesture`

## Configuration (`test/configuration.md`)
First consolidated `defineConfig` reference:
- Config file resolution and `--config`
- Grouped option tables (device/app, driver, test runner, timeouts/`use`, reporting) with types and defaults
- Local vs Mobile Next driver examples and per-project `use` overrides

Both are registered in `sidebars.js` and cross-link existing guides (auto-waiting, timeouts, retries, parallelism, projects).