### PR TITLE
fix(web-locator): coerce a non-boolean injected verdict so expect() fails cleanly

### DIFF
--- a/e2e/src/conformance/specs/assertions-missing.spec.ts
+++ b/e2e/src/conformance/specs/assertions-missing.spec.ts
@@ -1,0 +1,31 @@
+import type { Page, Expect } from '@playwright/test';
+import { pageWithBody } from './fixtures.js';
+
+// Assertions against a selector that matches nothing. This is where the injected
+// matcher hands back a verdict with no `matches` field; if that leaks through as
+// `pass: undefined`, expect() aborts with "Unexpected return from a matcher
+// function" instead of failing (or passing) the way Playwright does.
+export const missingElementAssertionsSpec = async (page: Page, expect: Expect): Promise<void> => {
+  await page.goto(pageWithBody('<button id="present">go</button>'));
+
+  const missing = page.locator('#nope');
+
+  // Presence matchers: a missing element is simply absent.
+  await expect(missing).not.toBeVisible();
+  await expect(missing).toHaveCount(0);
+
+  // Value matchers: Playwright fails these — even negated — because there is no
+  // element to read a value from. What matters here is that they fail as
+  // ordinary assertion failures.
+  await expectOrdinaryFailure(expect, expect(missing).toHaveText('go', { timeout: 1_000 }));
+  await expectOrdinaryFailure(expect, expect(missing).not.toHaveText('go', { timeout: 1_000 }));
+  await expectOrdinaryFailure(expect, expect(missing).not.toHaveAttribute('id', 'present', { timeout: 1_000 }));
+};
+
+// An assertion on a missing element must reject with a normal matcher failure,
+// never with Playwright's internal "Unexpected return from a matcher function".
+async function expectOrdinaryFailure(expect: Expect, assertion: Promise<void>): Promise<void> {
+  const error = await assertion.then(() => null, (e: Error) => e);
+  expect(error).toBeTruthy();
+  expect(error!.message).not.toContain('Unexpected return from a matcher function');
+}

--- a/e2e/src/conformance/specs/index.ts
+++ b/e2e/src/conformance/specs/index.ts
@@ -3,6 +3,7 @@ import { actionsSpec } from './actions.spec.js';
 import { stateAssertionsSpec } from './assertions-state.spec.js';
 import { textAssertionsSpec } from './assertions-text.spec.js';
 import { webAssertionsSpec } from './assertions-web.spec.js';
+import { missingElementAssertionsSpec } from './assertions-missing.spec.js';
 import { locatorsSpec } from './locators.spec.js';
 import { realNavigationSpec } from './real-navigation.spec.js';
 
@@ -19,6 +20,7 @@ export const conformanceSpecs: ConformanceCase[] = [
   { name: 'state assertions match Playwright', run: stateAssertionsSpec },
   { name: 'text assertions match Playwright (incl. whitespace normalization)', run: textAssertionsSpec },
   { name: 'web-only assertions match Playwright', run: webAssertionsSpec },
+  { name: 'assertions on a missing element behave like Playwright', run: missingElementAssertionsSpec },
   { name: 'locator factories resolve like Playwright', run: locatorsSpec },
   { name: 'navigates to a live page and drives it like Playwright', run: realNavigationSpec },
 ];

--- a/packages/mobilewright-core/src/web-locator-pwexpect.test.ts
+++ b/packages/mobilewright-core/src/web-locator-pwexpect.test.ts
@@ -39,3 +39,28 @@ test('expect(locator).toBeVisible() throws when the injected matcher does not ma
   }
   pwExpect(threw).toBe(true);
 });
+
+// Regression: a malformed verdict (matches is undefined, e.g. no element matched
+// the selector) must NOT leak back to Playwright as pass: undefined, which it
+// rejects with "Unexpected return from a matcher function". We coerce to false.
+function webLocatorWithMalformedVerdict(): Locator {
+  const { session } = fakeWebViewSession({ evaluateAlways: { received: undefined } });
+  return new WebLocator(session, 'internal:role=button') as unknown as Locator;
+}
+
+test('expect(locator).toBeVisible() fails cleanly when the verdict has no matches field', async () => {
+  const locator = webLocatorWithMalformedVerdict();
+  let error: Error | undefined;
+  try {
+    await pwExpect(locator).toBeVisible({ timeout: 0 });
+  } catch (e) {
+    error = e as Error;
+  }
+  pwExpect(error).toBeTruthy();
+  pwExpect(error!.message).not.toContain('Unexpected return from a matcher function');
+});
+
+test('expect(locator).not.toBeVisible() passes when the verdict has no matches field', async () => {
+  const locator = webLocatorWithMalformedVerdict();
+  await pwExpect(locator).not.toBeVisible({ timeout: 0 });
+});

--- a/packages/mobilewright-core/src/web-locator.ts
+++ b/packages/mobilewright-core/src/web-locator.ts
@@ -422,9 +422,13 @@ export class MobileWebViewLocator {
         isNot,
         timeout: 0,
       });
-      lastMatches = result.matches;
+      // The injected matcher can hand back a non-boolean verdict (e.g. no element
+      // matched the selector yet). Coerce to a strict boolean so a stray undefined
+      // never leaks back to Playwright as pass: undefined ("Unexpected return from
+      // a matcher function"); treat anything but true as not-matched and keep polling.
+      lastMatches = result.matches === true;
       received = result.received;
-      return result.matches !== isNot;
+      return lastMatches !== isNot;
     };
 
     let reached = await check();


### PR DESCRIPTION
`MobileWebViewLocator._expect()` passed the injected matcher's `matches` straight back to Playwright. When the verdict carries no `matches` field, that surfaces as `pass: undefined`, and Playwright aborts the assertion with `Unexpected return from a matcher function` instead of failing normally.

Coerced with `result.matches === true` — anything but `true` counts as not-matched, and polling continues until the timeout.

## Tests

**Unit** (`web-locator-pwexpect.test.ts`) — two cases driving a fake session whose verdict has no `matches` field. Both fail with `Unexpected return from a matcher function` when the fix is reverted, and pass with it.

**Conformance** (`e2e/src/conformance/specs/assertions-missing.spec.ts`) — assertions against a selector matching nothing, run from one file under both the Playwright (chromium oracle) and mobilewright (on-device) runners: `not.toBeVisible()` / `toHaveCount(0)` pass, while `toHaveText` / `not.toHaveText` / `not.toHaveAttribute` fail as ordinary assertion failures.

Verified green on chromium, an iOS simulator, and an Android emulator.

Note: the conformance spec does not reproduce this bug — it passes on iOS and Android with the fix reverted, because both webviews return a proper boolean `matches` for these matchers. It guards missing-element behavior generally; the unit tests are what cover the coercion.

660 core tests pass; `npm run lint` clean.