### PR TITLE
refactor(inspector): share core's role map and type normalization

### DIFF
--- a/packages/inspector/src/lib/locator-derivation.test.ts
+++ b/packages/inspector/src/lib/locator-derivation.test.ts
@@ -146,6 +146,30 @@ test.describe('deriveLocator — role type mapping', () => {
   });
 });
 
+// mobilecli reports native types verbatim, so a real Android dump is full of
+// fully-qualified names and iOS may keep the XCUIElementType prefix. Derivation
+// must normalize them the same way core's getByRole matching does, otherwise the
+// Inspector suggests no role for nodes getByRole would happily match.
+test.describe('deriveLocator — fully-qualified native types', () => {
+  const fullyQualifiedCases: [string, string][] = [
+    ['android.widget.Button',                                                    'button'],
+    ['android.widget.EditText',                                                  'textfield'],
+    ['android.widget.TextView',                                                  'text'],
+    ['androidx.appcompat.widget.AppCompatTextView',                              'text'],
+    ['com.google.android.material.floatingactionbutton.FloatingActionButton',    'button'],
+    ['XCUIElementTypeButton',                                                    'button'],
+    ['XCUIElementTypeSecureTextField',                                           'textfield'],
+  ];
+
+  for (const [type, expectedRole] of fullyQualifiedCases) {
+    test(`${type} -> ${expectedRole}`, () => {
+      const result = deriveLocator(node({ type }));
+      expect(result?.kind).toBe('role');
+      expect(result?.value).toBe(expectedRole);
+    });
+  }
+});
+
 // ---- Case-insensitive type ----
 
 test.describe('deriveLocator — case insensitive type', () => {

--- a/packages/inspector/src/lib/locator-derivation.ts
+++ b/packages/inspector/src/lib/locator-derivation.ts
@@ -1,24 +1,19 @@
 // Derives the best mobilewright locator for every node in a ViewNode tree.
-// Priority: Test ID > Role > Label > Text. Mirrors @mobilewright/core query-engine.ts.
-// If mobilewright changes matching rules, update ROLE_TYPE_MAP below to stay in sync.
+// Priority: Test ID > Role > Label > Text. Mirrors @mobilewright/core query-engine.ts,
+// and reuses its ROLE_TYPE_MAP so role derivation cannot drift from role matching.
 
 import type { ViewNode } from '@mobilewright/protocol';
+import { ROLE_TYPE_MAP, bareTypeName } from '@mobilewright/core';
 
-/** Maps mobilewright role names to the node type strings that resolve to each role. */
-const ROLE_TYPE_MAP: Record<string, string[]> = {
-  button:   ['button', 'imagebutton'],
-  textfield: ['textfield', 'securetextfield', 'edittext', 'searchfield', 'reactedittext'],
-  text:     ['statictext', 'textview', 'text', 'reacttextview'],
-  image:    ['image', 'imageview', 'reactimageview'],
-  switch:   ['switch', 'toggle'],
-  checkbox: ['checkbox'],
-  slider:   ['slider', 'seekbar'],
-  list:     ['table', 'collectionview', 'listview', 'recyclerview', 'scrollview', 'reactscrollview'],
-  listitem: ['cell', 'linearlayout', 'relativelayout'],
-  tab:      ['tab', 'tabbar'],
-  link:     ['link'],
-  header:   ['navigationbar', 'toolbar', 'header'],
-};
+// core declares ROLE_TYPE_MAP `as const`, so each value is a readonly tuple of
+// string literals. Widen to plain strings once, here, so membership can be tested
+// against an arbitrary node type.
+const ROLE_TYPES: [string, readonly string[]][] = Object.entries(ROLE_TYPE_MAP);
+
+// Types that ROLE_TYPE_MAP matches on purpose but that must not be *suggested*:
+// iOS reports generic containers as "other", so deriving getByRole('listitem')
+// from one would hand the user a locator matching much of the tree.
+const TYPES_TOO_GENERIC_TO_SUGGEST = new Set(['other']);
 
 /** Discriminated union of the four locator strategies mobilewright supports. */
 export type Locator =
@@ -29,15 +24,23 @@ export type Locator =
 
 /** Map node.type to a mobilewright role string. Returns null for unmapped types. */
 function deriveRole(node: ViewNode): string | null {
-  const type = (node.type ?? '').toLowerCase();
+  // Same normalization core applies before matching: strips the Android package
+  // path ("android.widget.EditText") and the iOS "XCUIElementType" prefix.
+  const type = bareTypeName(node.type ?? '');
 
   if (type === 'reactviewgroup') {
     const isClickable = node.raw?.['clickable'] === 'true' || node.raw?.['accessible'] === 'true';
     return isClickable ? 'button' : null;
   }
 
-  for (const [role, types] of Object.entries(ROLE_TYPE_MAP)) {
-    if (types.includes(type)) return role;
+  if (TYPES_TOO_GENERIC_TO_SUGGEST.has(type)) {
+    return null;
+  }
+
+  for (const [role, types] of ROLE_TYPES) {
+    if (types.includes(type)) {
+      return role;
+    }
   }
   return null;
 }

--- a/packages/mobilewright-core/src/index.ts
+++ b/packages/mobilewright-core/src/index.ts
@@ -5,6 +5,6 @@ export { Device, type DeviceOptions } from './device.js';
 export { MobileWebViewPage, MobileWebViewPage as Page } from './page.js';
 export { MobileWebViewLocator, MobileWebViewLocator as WebLocator } from './web-locator.js';
 export { expect, ExpectError, type ExpectOptions } from './expect.js';
-export { queryAll, ROLE_TYPE_MAP, type LocatorStrategy, type Role } from './query-engine.js';
+export { queryAll, ROLE_TYPE_MAP, bareTypeName, type LocatorStrategy, type Role } from './query-engine.js';
 export { sleep } from './sleep.js';
 export type { HardwareButton } from '@mobilewright/protocol';

--- a/packages/mobilewright-core/src/query-engine.ts
+++ b/packages/mobilewright-core/src/query-engine.ts
@@ -208,7 +208,7 @@ export type Role = keyof typeof ROLE_TYPE_MAP;
  * "XCUIElementType" prefix ("XCUIElementTypeTextField"). getByType still matches the
  * raw type — only role resolution normalizes.
  */
-function bareTypeName(type: string): string {
+export function bareTypeName(type: string): string {
   const lower = type.toLowerCase();
   const afterPackage = lower.includes('.') ? lower.slice(lower.lastIndexOf('.') + 1) : lower;
   return afterPackage.startsWith('xcuielementtype')


### PR DESCRIPTION
The Inspector kept its own copy of `ROLE_TYPE_MAP`, with a comment admitting the sync was manual ("If mobilewright changes matching rules, update ROLE_TYPE_MAP below to stay in sync"). It had already drifted, and #186 widened the gap further by adding the Material/AppCompat aliases to core only.

Now it imports core's map, so the Inspector's role *derivation* cannot diverge from `getByRole`'s role *matching*.

## A real bug this exposed

The Inspector never stripped fully-qualified native types, so on a real Android dump it derived **no role at all** for every `android.widget.*` node — while `getByRole('button')` matched them fine. Same drift, opposite direction.

Fixed by exporting core's `bareTypeName()` and using it, so both sides normalize identically. 7 tests cover it (all 7 fail without the change).

## Two deliberate differences kept

- **`other` is still not suggested.** Core maps `other` → `listitem`, which is right for matching but bad as a suggestion: iOS reports generic containers as `other`, so `getByRole('listitem')` would match much of the tree. Now an explicit `TYPES_TOO_GENERIC_TO_SUGGEST` set instead of an accidental consequence of a stale copy. The existing test that pinned this still passes.
- **Entries widened once.** `as const` in core narrows values to readonly tuples of literals, which makes `types.includes(nodeType)` a type error. Widened at module scope rather than cast at the call site.

## Result

The Inspector picks up `materialbutton`, `appcompatedittext`, `shapeableimageview` and the rest for free, and future role changes reach it automatically.

752 tests pass; `npm run lint` clean.