### PR TITLE
chore: update mobilecli to 0.3.88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/mobilecli": {
-      "version": "0.3.85",
-      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-0.3.85.tgz",
-      "integrity": "sha512-Sr799t3YgF8Zu5kJH3baGh4m8GQ47MVDbGJ/odfUgug7esh4c+dBdLIyDZ/+ZzacJ6H9n/B8lXq/oAxoTJHvjw==",
+      "version": "0.3.88",
+      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-0.3.88.tgz",
+      "integrity": "sha512-qrd1SGX62IF3tEuYoc60DfGmej7zvQwMU9EfybUoh6j2oVxxkEIUg49AAipby3gbf255hnz4CnxMFVoK5hlZcw==",
       "license": "MIT",
       "bin": {
         "mobilecli": "index.js"
@@ -3647,7 +3647,7 @@
       "dependencies": {
         "@mobilewright/protocol": "^0.0.1",
         "debug": "^4.4.3",
-        "mobilecli": "0.3.85",
+        "mobilecli": "0.3.88",
         "ws": "^8.18.0"
       },
       "devDependencies": {

--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@mobilewright/protocol": "^0.0.1",
     "debug": "^4.4.3",
-    "mobilecli": "0.3.85",
+    "mobilecli": "0.3.88",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the `mobilecli` dependency in `@mobilewright/driver-mobilecli` from 0.3.85 to 0.3.88.

`npm run lint` passes.