### PR TITLE
docs: sync changelog for 0.0.51

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,13 @@ hide_table_of_contents: true
 
 # Changelog
 
+## [0.0.51] (2026-07-29)
+* Feat(expect): support a custom message argument, like Playwright ([#241](https://github.com/mobile-next/mobilewright/pull/241))
+* Fix(core): match Android fully-qualified widget types in getByRole and export the Role type ([#186](https://github.com/mobile-next/mobilewright/pull/186)), thanks to [@Dhakshath11](https://github.com/Dhakshath11)
+* Fix(web-locator): coerce a non-boolean injected verdict so expect() fails cleanly ([#243](https://github.com/mobile-next/mobilewright/pull/243))
+* Refactor(inspector): share core's role map and type normalization, so role suggestions match getByRole on Android ([#244](https://github.com/mobile-next/mobilewright/pull/244))
+* Chore: update mobilecli to 0.3.88 which fixes app installation timeouts over jsonrpc
+
 ## [0.0.50] (2026-07-15)
 * Feat(driver-mobilenext): allocate devices via the sessions REST API ([#228](https://github.com/mobile-next/mobilewright/pull/228))
 * Feat(inspector): add element attributes in sidebar ([#227](https://github.com/mobile-next/mobilewright/pull/227)), thanks to [@sarang-code2](https://github.com/sarang-code2)


### PR DESCRIPTION
`docs/src/changelog.md` was missing the entire `0.0.51` section added to `CHANGELOG.md` in #245. This copies that block over verbatim, so the two files are in sync again.

Verified: `diff <(tail -n +10 docs/src/changelog.md) CHANGELOG.md` is empty.