### PR TITLE
perf(driver-mobilecli): check agent status once per device instead of per test

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -33,6 +33,13 @@ import { resolveMobilecliBinary } from './resolve-binary.js';
 
 export const DEFAULT_URL = 'ws://localhost:12000/ws';
 
+/**
+ * Device IDs whose agent has already been verified in this process. connect()
+ * runs once per test, but the agent doesn't come and go during a run, so the
+ * `mobilecli agent status` subprocess only needs to be spawned once per device.
+ */
+const agentVerified = new Set<string>();
+
 // ─── mobilecli RPC response types ─────────────────────────────
 
 /** Element shape returned by mobilecli's device.dump.ui JSON response */
@@ -318,12 +325,17 @@ export class MobilecliDriver implements MobilewrightDriver {
   }
 
   private ensureAgentInstalled(device: DeviceInfo): void {
+    if (agentVerified.has(device.id)) {
+      debug('agent already verified on %s, skipping status check', device.id);
+      return;
+    }
     const binary = resolveMobilecliBinary();
     debug('running: %s agent status --device %s', binary, device.id);
     const statusOutput = execFileSync(binary, ['agent', 'status', '--device', device.id], { encoding: 'utf8' });
     debug('agent status output: %s', statusOutput.trim());
     const statusResponse = JSON.parse(statusOutput) as MobilecliAgentStatusResponse;
     if (statusResponse.status === 'ok') {
+      agentVerified.add(device.id);
       return;
     }
     if (device.type === 'simulator' || device.type === 'emulator') {
@@ -336,6 +348,7 @@ export class MobilecliDriver implements MobilewrightDriver {
       if (verifyResponse.status !== 'ok') {
         throw new Error(`agent install failed on ${device.type} ${device.id}: ${verifyResponse.data?.message ?? 'unknown error'}`);
       }
+      agentVerified.add(device.id);
       return;
     }
     throw new Error(`agent not installed, run \`npx mobilewright install --device ${device.id}\` to get started`);


### PR DESCRIPTION
`ensureAgentInstalled()` is called from `connect()`, and the test fixture connects once per test — so every test spawned a `mobilecli agent status` subprocess for the same device, ~1.1s each. The agent doesn't come and go mid-run, so this only needs to happen once per device.

Adds a module-level `Set` of verified device IDs, populated at both success paths (the `status === 'ok'` early return, and after the auto-install verify).

## Measurements

Real suite, 15 tests, one iOS simulator, single worker:

| | agent spawns | total |
|---|---|---|
| before | 15 (18.0s) | 3.0m |
| after | 5 (6.0s) | 2.7m |

Same results before and after (11 passed / 4 failed — the 4 failures are intentional `should fail` tests in that suite).

## Why 5 and not 1

The cache is per worker process, and Playwright tears down the worker after a test failure. Tracing spawns against outcomes, each one lands right after a failed test:

```
>>> SPAWN   ✓1  skip ✘2  >>> SPAWN  ✘3  >>> SPAWN
✓4 skip ✓5 skip ✓6 skip ✓7 skip ✓8 skip ✓9 skip ✘10  >>> SPAWN
✓11 skip ✓12 skip ✘13  >>> SPAWN  ✓14 skip ✓15
```

1 initial worker + 4 restarts = 5 processes, each checking once. All 10 tests that didn't follow a restart hit the cache. A green run does 1 check total; `workers: N` does N.

A pool-scoped version would survive worker restarts — `DeviceSlot` already has this exact pattern in `_installedApps` (`device-pool/domain/device-slot.ts:21`), where `release()` deliberately doesn't clear the set. That's ~5 files and a `ConnectionConfig` field to save one subprocess per worker, so I left it; happy to do it if you'd rather have it there.

## Testing

- `npm run lint` clean
- `npm test` — 558 passed, 1 skipped
- Verified end-to-end against a real simulator suite (numbers above)

No unit test added: `ensureAgentInstalled` is private and calls `execFileSync` directly with no injection seam, and the existing driver tests bypass `connect()` entirely via `createDriverWithSession`. Testing it would mean mocking `node:child_process`. Say the word if you want that.
