### PR TITLE
feat(driver-mobilecli): surface isSelected/isChecked/isFocused from dump.ui

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -48,6 +48,9 @@ interface MobilecliElement {
   children?: MobilecliElement[];
   visible?: boolean;
   enabled?: boolean;
+  selected?: boolean;
+  checked?: boolean;
+  focused?: boolean;
 }
 
 interface MobilecliAppEntry {
@@ -145,6 +148,9 @@ function elementToViewNode(el: MobilecliElement): ViewNode {
     placeholder: el.placeholder || undefined,
     isVisible: typeof el.visible === 'boolean' ? el.visible : bounds.width > 0 && bounds.height > 0,
     isEnabled: el.enabled ?? true,
+    isSelected: typeof el.selected === 'boolean' ? el.selected : undefined,
+    isChecked: typeof el.checked === 'boolean' ? el.checked : undefined,
+    isFocused: typeof el.focused === 'boolean' ? el.focused : undefined,
     bounds,
     children: el.children?.map(elementToViewNode) ?? [],
     raw: { ...el },


### PR DESCRIPTION
## Summary

`ViewNode` already declares `isSelected` / `isChecked` / `isFocused`, and `@mobilewright/core`'s `expect` ships `toBeSelected()` / `toBeChecked()` — but `elementToViewNode` never populated those fields, so the matchers read `false` for every node.

This maps the three flags through from the mobilecli element. Reads are guarded on `typeof === 'boolean'`, so they stay `undefined` when the agent omits them — **no behavior change** until the on-device agent emits them.

## Diff

- `MobilecliElement`: add optional `selected` / `checked` / `focused`.
- `elementToViewNode`: map them to `isSelected` / `isChecked` / `isFocused`.

## Scope / follow-up

This is the driver half only. For the values to become non-`undefined`, the on-device agent must include `selected` / `checked` / `focused` (from `AccessibilityNodeInfo`) in each `device.dump.ui` element — and ideally Android `stateDescription`, which Jetpack Compose populates for a `selected` semantic on non-`Role.Tab` nodes. Tracking that separately.

Refs #250

## Test

`elementToViewNode` is a private function with no unit-test seam today (only the live-server `integration.test.ts`), so no unit test is added here to avoid exporting internals. `tsc -b` builds clean. Happy to add a fixture/test if you'd prefer to expose it.