### PR TITLE
fix: map android ToggleButton to switch role and fix stale locator docs

### DIFF
--- a/docs/src/guides/locators.md
+++ b/docs/src/guides/locators.md
@@ -47,6 +47,23 @@ the app uses `AppCompatEditText`).
 | `android.widget.RelativeLayout` | `listitem` |
 | `android.widget.Toolbar` | `header` |
 
+### AndroidX / Material Components
+
+Some dumps surface the AndroidX or Material Components subclass name directly instead
+of the collapsed framework class above — these are also recognized:
+
+| Native class | `getByRole()` |
+| --- | --- |
+| `androidx.appcompat.widget.AppCompatButton` | `button` |
+| `com.google.android.material.button.MaterialButton` | `button` |
+| `com.google.android.material.floatingactionbutton.FloatingActionButton` | `button` |
+| `androidx.appcompat.widget.AppCompatEditText` | `textfield` |
+| `com.google.android.material.textfield.TextInputEditText` | `textfield` |
+| `androidx.appcompat.widget.AppCompatTextView` | `text` |
+| `com.google.android.material.textview.MaterialTextView` | `text` |
+| `androidx.appcompat.widget.AppCompatImageView` | `image` |
+| `com.google.android.material.imageview.ShapeableImageView` | `image` |
+
 ### React Native (Android)
 
 | Native class | `getByRole()` |
@@ -89,9 +106,9 @@ the app uses `AppCompatEditText`).
 
 - **iOS source filtering.** mobilecli currently surfaces only a subset of iOS
   classes — `Button`, `TextField`, `SecureTextField`, `SearchField`, `Switch`,
-  `StaticText`, `Image`, `Icon`, `WebView`. Other rows in the iOS table
-  (`Slider`, `Table`, `CollectionView`, `Cell`, `Tab`, `NavigationBar`, `Link`,
-  `TextView`) are filtered out before they reach the query engine, so `getByRole()`
+  `StaticText`, `Image`, `Icon`, `WebView`, `TextView`. Other rows in the iOS table
+  (`Slider`, `Table`, `CollectionView`, `Cell`, `Tab`, `NavigationBar`, `Link`)
+  are filtered out before they reach the query engine, so `getByRole()`
   cannot match them yet even though the mapping exists.
 
 - **`TextView` is platform-ambiguous.** On Android, `TextView` is a static label

--- a/packages/mobilewright-core/src/query-engine.test.ts
+++ b/packages/mobilewright-core/src/query-engine.test.ts
@@ -337,6 +337,7 @@ test.describe('fully-qualified native types from real device dumps', () => {
     node({ type: 'android.widget.EditText', label: 'password_field', text: 'Password' }),
     node({ type: 'android.widget.EditText', label: 'multiline_text', text: 'Multiline text' }),
     node({ type: 'android.widget.Switch', label: 'toggle' }),
+    node({ type: 'android.widget.ToggleButton', label: 'Wi-Fi' }),
     node({ type: 'android.widget.Button', text: 'RESET COUNTER' }),
     node({ type: 'android.widget.ImageButton', label: 'Navigate up' }),
   ];
@@ -346,9 +347,9 @@ test.describe('fully-qualified native types from real device dumps', () => {
     expect(results).toHaveLength(3);
   });
 
-  test('fully-qualified android Switch matches the switch role', () => {
+  test('fully-qualified android Switch and ToggleButton match the switch role', () => {
     const results = queryAll(androidScreen, { kind: 'role', value: 'switch' });
-    expect(results).toHaveLength(1);
+    expect(results).toHaveLength(2);
   });
 
   test('fully-qualified android Button and ImageButton match the button role', () => {

--- a/packages/mobilewright-core/src/query-engine.ts
+++ b/packages/mobilewright-core/src/query-engine.ts
@@ -144,6 +144,9 @@ function matchesStrategy(
     case 'role':
       if (!matchesRole(node, strategy.value)) return false;
       if (strategy.name !== undefined) {
+        // Accessible-name order (label before text) is intentionally the reverse of
+        // the `text` locator above: an explicit label/accessibilityLabel outranks
+        // displayed text, mirroring ARIA accessible-name computation.
         const nodeLabel = node.label ?? node.text ?? '';
         if (strategy.name instanceof RegExp) {
           return strategy.name.test(nodeLabel);

--- a/packages/mobilewright-core/src/query-engine.ts
+++ b/packages/mobilewright-core/src/query-engine.ts
@@ -184,7 +184,7 @@ export const ROLE_TYPE_MAP = {
   textfield: ['textfield', 'securetextfield', 'searchfield', 'edittext', 'appcompatedittext', 'textinputedittext', 'reactedittext'],
   text: ['statictext', 'textview', 'appcompattextview', 'materialtextview', 'text', 'reacttextview'],
   image: ['image', 'imageview', 'appcompatimageview', 'shapeableimageview', 'reactimageview'],
-  switch: ['switch', 'toggle'],
+  switch: ['switch', 'toggle', 'togglebutton'],
   checkbox: ['checkbox'],
   slider: ['slider', 'seekbar'],
   list: ['table', 'collectionview', 'listview', 'recyclerview', 'scrollview', 'reactscrollview'],


### PR DESCRIPTION
## Summary
- `getByRole('switch')` didn't match `android.widget.ToggleButton` even though the locators doc claimed it did — `ROLE_TYPE_MAP.switch` had an unreachable `'toggle'` entry instead of `'togglebutton'`. Added the correct entry.
- Locators doc said iOS `TextView` is filtered out before reaching the query engine; mobilecli's `acceptedTypes` (pinned at 0.3.89) already surfaces it, so the doc was stale.
- Documented the AndroidX/Material Components subclasses (`AppCompatButton`, `MaterialButton`, `FloatingActionButton`, `AppCompatEditText`, `TextInputEditText`, `AppCompatTextView`, `MaterialTextView`, `AppCompatImageView`, `ShapeableImageView`) that `ROLE_TYPE_MAP` already recognized but the docs never listed.

## Test plan
- [x] Added a `ToggleButton` case to the existing "fully-qualified native types" test suite in `query-engine.test.ts`, confirmed it passes: `npx playwright test --config=tests/mobilewright.config.ts packages/mobilewright-core/src/query-engine.test.ts -g "switch role"`
- [x] `npm run lint` passes