### PR TITLE
feat: add per-project deviceId and expose resolved device.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ await expect(page.getByText('Welcome')).toBeVisible();
 Manages the connection lifecycle and exposes device/app-level controls.
 
 ```typescript
+// Resolved device identifier (Android serial / iOS UDID) — useful for out-of-band adb/xcrun calls
+console.log(device.id);
+
 // Orientation
 await device.setOrientation('landscape');
 const orientation = await device.getOrientation();
@@ -389,6 +392,7 @@ The `use` object holds per-action defaults shared by every test:
 | `use` option | Type | Description |
 |---|---|---|
 | `platform` | `'ios' \| 'android'` | Platform for the run (optional) |
+| `deviceId` | `string` | Specific device identifier (local drivers only) — overrides the top-level `deviceId` for this project (optional) |
 | `deviceName` | `RegExp` | RegExp to match device name (optional) |
 | `bundleId` | `string` | App bundle ID (optional) |
 | `installApps` | `string \| string[]` | App paths to install — overrides top-level `installApps` (optional) |
@@ -438,6 +442,7 @@ The `device` fixture connects once per worker (reading from `mobilewright.config
 |---|---|---|
 | `bundleId` | `string` | App bundle ID for these tests |
 | `platform` | `'ios' \| 'android'` | Target platform |
+| `deviceId` | `string` | Specific device identifier (local drivers only) |
 | `deviceName` | `RegExp` | RegExp to match the device name |
 | `installApps` | `string \| string[]` | App paths (APK/IPA) to install before the tests run |
 | `autoAppLaunch` | `boolean` | Launch the app automatically before each test. Default: `true` |

--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ await expect(page.getByText('Welcome')).toBeVisible();
 Manages the connection lifecycle and exposes device/app-level controls.
 
 ```typescript
-// Resolved device identifier (Android serial / iOS UDID) — useful for out-of-band adb/xcrun calls
 console.log(device.id);
 
 // Orientation

--- a/docs/src/test/configuration.md
+++ b/docs/src/test/configuration.md
@@ -134,4 +134,4 @@ export default defineConfig({
 });
 ```
 
-The project `use` block accepts `platform`, `deviceName`, `bundleId`, `installApps`, `animations`, `actionTimeout`, `appLaunchTimeout`, and `installTimeout`. Projects can also override `timeout`, `testDir`, `testMatch`, `testIgnore`, `outputDir`, `retries`, `grep`, `grepInvert`, and declare `dependencies` on other projects. See [Projects](./projects.md) for the full matrix.
+The project `use` block accepts `platform`, `deviceId`, `deviceName`, `bundleId`, `installApps`, `animations`, `actionTimeout`, `appLaunchTimeout`, and `installTimeout`. Projects can also override `timeout`, `testDir`, `testMatch`, `testIgnore`, `outputDir`, `retries`, `grep`, `grepInvert`, and declare `dependencies` on other projects. See [Projects](./projects.md) for the full matrix.

--- a/docs/src/test/projects.md
+++ b/docs/src/test/projects.md
@@ -57,6 +57,7 @@ The `use` block inside each project accepts the same options as the top-level co
 | `platform` | `'ios'` or `'android'` |
 | `bundleId` | App bundle identifier |
 | `installApps` | APK or IPA/ZIP path(s) to install before tests run |
+| `deviceId` | Exact device ID to pin this project to (local drivers only) |
 | `deviceName` | Regex to match a specific device |
 
 A common pattern is to share `bundleId` and `timeout` at the top level, and only specify `platform` and `installApps` per project:

--- a/packages/mobilewright-core/src/device.test.ts
+++ b/packages/mobilewright-core/src/device.test.ts
@@ -72,3 +72,21 @@ test.describe('Device.applyDeviceSettings', () => {
     await expect(device.applyDeviceSettings({ animations: 'off' })).resolves.toBeUndefined();
   });
 });
+
+test.describe('Device.id', () => {
+  test('returns the deviceId from the connected session', async () => {
+    const driver = createMockDriver({ width: 390, height: 844, scale: 3 });
+    const device = new Device(driver);
+
+    await device.connect({ platform: 'ios' });
+
+    expect(device.id).toBe('device1');
+  });
+
+  test('throws when read before connect()', () => {
+    const driver = createMockDriver({ width: 390, height: 844, scale: 3 });
+    const device = new Device(driver);
+
+    expect(() => device.id).toThrow(/not connected yet/);
+  });
+});

--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -41,6 +41,7 @@ export class Device {
   readonly driver: MobilewrightDriver;
   private cleanupCallbacks: Array<() => Promise<void>> = [];
   private _screen: Screen | null = null;
+  private session: Session | null = null;
   private readonly opts: DeviceOptions;
 
   constructor(driver: MobilewrightDriver, opts: DeviceOptions = {}) {
@@ -56,7 +57,8 @@ export class Device {
   // ─── Connection lifecycle ────────────────────────────────────
 
   async connect(config: ConnectionConfig): Promise<Session> {
-    return this.driver.connect(config);
+    this.session = await this.driver.connect(config);
+    return this.session;
   }
 
   async disconnect(): Promise<void> {
@@ -84,6 +86,14 @@ export class Device {
   get screen(): Screen {
     this._screen ??= new Screen(this.driver, this.opts.locatorDefaults);
     return this._screen;
+  }
+
+  /** The physical device identifier (Android serial / iOS UDID) this device connected to. */
+  get id(): string {
+    if (!this.session) {
+      throw new Error('Device.id: not connected yet');
+    }
+    return this.session.deviceId;
   }
 
   // ─── Device control ──────────────────────────────────────────

--- a/packages/mobilewright/src/config.test.ts
+++ b/packages/mobilewright/src/config.test.ts
@@ -41,6 +41,13 @@ test('defineConfig with project use.installApps is preserved', () => {
   expect(config.projects![0].use!.installApps).toBe('per-project.apk');
 });
 
+test('defineConfig with project use.deviceId is preserved', () => {
+  const config = defineConfig({
+    projects: [{ name: 'android', use: { deviceId: 'emulator-5554' } }],
+  });
+  expect(config.projects![0].use!.deviceId).toBe('emulator-5554');
+});
+
 test('toArray returns empty array for undefined', () => {
   expect(toArray(undefined)).toEqual([]);
 });

--- a/packages/mobilewright/src/config.ts
+++ b/packages/mobilewright/src/config.ts
@@ -15,6 +15,8 @@ const _require = createRequire(import.meta.url);
 export interface MobilewrightUseOptions {
   /** Platform for this project. */
   platform?: 'ios' | 'android';
+  /** Specific device identifier (local drivers only). Overrides the top-level deviceId for this project. */
+  deviceId?: string;
   /** Regex to match device name. */
   deviceName?: RegExp;
   /** App bundle ID for this project. */

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -48,6 +48,7 @@ type MobilewrightTestFixtures = {
   bundleId: string | undefined;
   autoAppLaunch: boolean | undefined;
   platform: 'ios' | 'android' | undefined;
+  deviceId: string | undefined;
   deviceName: RegExp | undefined;
   installApps: string | string[] | undefined;
   viewTree: 'on-failure' | 'off';
@@ -74,6 +75,7 @@ export const test = base.extend<MobilewrightTestFixtures>({
   }, { option: true }],
 
   platform: [undefined, { option: true }],
+  deviceId: [undefined, { option: true }],
   deviceName: [undefined, { option: true }],
   installApps: [undefined, { option: true }],
 
@@ -87,13 +89,14 @@ export const test = base.extend<MobilewrightTestFixtures>({
     await use(value);
   }, { option: true }],
 
-  device: async ({ platform, deviceName, bundleId, autoAppLaunch, installApps }, use, testInfo) => {
+  device: async ({ platform, deviceId, deviceName, bundleId, autoAppLaunch, installApps }, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
     const project = config.projects?.find(p => p.name === testInfo.project.name);
     const projectUse = { ...config.use, ...project?.use };
     const merged = {
       ...config,
       ...(platform && { platform }),
+      ...(deviceId !== undefined && { deviceId }),
       ...(deviceName && { deviceName }),
       ...(installApps !== undefined && { installApps }),
       use: projectUse,


### PR DESCRIPTION
Closes #236.

## Summary
- Added `deviceId` to `MobilewrightUseOptions` so a `projects[].use` block can pin that project to a specific device by ID, not just by `deviceName` regex.
- Registered `deviceId` as a full Playwright option-fixture in `@mobilewright/test`, mirroring `deviceName` — resolvable via `test.use()`, `project.use`, or top-level `use`, with the legacy top-level `MobilewrightConfig.deviceId` as a fallback.
- Exposed the resolved device id at runtime via `device.id` on the `Device` class (captured from the `Session` returned by `driver.connect()`, previously discarded), so tests/`globalSetup` can pass the exact device serial/UDID to out-of-band `adb`/`xcrun` calls.
- Updated README and the test docs (`configuration.md`, `projects.md`) to document `deviceId` alongside `deviceName` — `fixtures.md` already (prematurely) documented it, so no change was needed there.

Co-authored-by: Rahul Thakur (@rahulLeadsquared), who filed the request in #236.

## Test plan
- [x] `npm run lint` (tsc --noEmit + eslint) passes
- [x] New unit tests added and passing:
  - `defineConfig with project use.deviceId is preserved` (`config.test.ts`)
  - `Device.id` returns the connected session's deviceId / throws when read before `connect()` (`device.test.ts`)
- [x] Existing allocator tests (`mobilecli-allocator.test.ts`, `mobilenext-allocator.test.ts`) re-run and still pass unchanged — the allocator layer already fully supported `AllocationCriteria.deviceId`, only the fixture wiring was missing