### PR TITLE
feat: send mobilewright User-Agent header on fleet API requests

### DIFF
--- a/packages/driver-mobilenext/src/fleet-api.test.ts
+++ b/packages/driver-mobilenext/src/fleet-api.test.ts
@@ -6,6 +6,7 @@ interface RecordedCall {
   path: string;
   body: unknown;
   authorization: string | null;
+  userAgent: string | null;
 }
 
 interface StubResponse {
@@ -26,6 +27,7 @@ function stubFetch(responses: StubResponse[]): { fetchFn: typeof fetch; calls: R
       path: new URL(url).pathname,
       body: init.body ? JSON.parse(init.body as string) : undefined,
       authorization: headers?.['Authorization'] ?? null,
+      userAgent: headers?.['User-Agent'] ?? null,
     });
     const chosen = responses[Math.min(index, responses.length - 1)];
     index += 1;
@@ -68,6 +70,7 @@ test('createSession posts to the sessions endpoint with a bearer token', async (
   expect(calls[0].method).toBe('POST');
   expect(calls[0].path).toBe('/api/v1/sessions');
   expect(calls[0].authorization).toBe('Bearer mob_test');
+  expect(calls[0].userAgent).toMatch(/^mobilewright\/\d+\.\d+\.\d+$/);
 });
 
 test('allocateDevice returns immediately for a pre-booted device (serial is device.id)', async () => {

--- a/packages/driver-mobilenext/src/fleet-api.ts
+++ b/packages/driver-mobilenext/src/fleet-api.ts
@@ -1,6 +1,11 @@
 import createDebug from 'debug';
+import { createRequire } from 'node:module';
 
 const debug = createDebug('mw:driver-mobilenext:fleet-api');
+
+const _require = createRequire(import.meta.url);
+const _pkg = _require('../package.json') as { version: string };
+const USER_AGENT = `mobilewright/${_pkg.version}`;
 
 export const DEFAULT_API_URL = 'https://api.mobilenext.ai';
 
@@ -187,7 +192,10 @@ export class FleetApiClient {
   }
 
   private async request<T = void>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
-    const headers: Record<string, string> = { 'Authorization': `Bearer ${this.apiKey}` };
+    const headers: Record<string, string> = {
+      'Authorization': `Bearer ${this.apiKey}`,
+      'User-Agent': USER_AGENT,
+    };
     if (body !== undefined) {
       headers['Content-Type'] = 'application/json';
     }


### PR DESCRIPTION
## Summary
- Send a `User-Agent: mobilewright/x.y.z` header on every mobilenext fleet REST call (session creation, device allocation, release, and provisioning polls) by adding it in `FleetApiClient`'s single shared `request()` helper.
- Version is read from the driver's own `package.json` at module load, following the same pattern already used in `reporter.ts` for report uploads. All packages in this monorepo are version-locked together at release, so this matches the root `mobilewright` package version.

## Test plan
- [x] `npm run lint`
- [x] `npx playwright test fleet-api.test.ts` (14/14 passing) — added an assertion that `createSession` sends `User-Agent: mobilewright/<version>`