### PR TITLE
docs: add unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 ## [Unreleased]
 * Feat: accept driver instances instead of `{type, ...}` config objects ([#260](https://github.com/mobile-next/mobilewright/pull/260)); legacy config objects are converted automatically with a deprecation warning ([#267](https://github.com/mobile-next/mobilewright/pull/267))
-* Feat: drivers can observe the test run via `TestObserver` lifecycle hooks (`onRunStart`, `onTestEnd`, `onRunEnd`) — mobilenext test-result upload happens automatically again, no reporter configuration needed ([#267](https://github.com/mobile-next/mobilewright/pull/267))
-* Feat: send mobilewright User-Agent header on fleet API requests ([#263](https://github.com/mobile-next/mobilewright/pull/263))
+* Feat: drivers can observe the test run via `TestObserver` lifecycle hooks (`onRunStart`, `onTestEnd`, `onRunEnd`) ([#267](https://github.com/mobile-next/mobilewright/pull/267))
 * Fix: screen and device actions (`screenshot`, `swipe`, `launchApp`, `terminateApp`, …) now appear as steps in the test report ([#267](https://github.com/mobile-next/mobilewright/pull/267))
 * Refactor: split the driver contract into `DeviceAllocator` and `MobilewrightSession` interfaces ([#267](https://github.com/mobile-next/mobilewright/pull/267))
-* Chore: update packages ([#261](https://github.com/mobile-next/mobilewright/pull/261))
+* Chore: update brace-expansion package for security ([#261](https://github.com/mobile-next/mobilewright/pull/261))
 
 ## [0.0.52] (2026-08-01)
 * Feat: add per-project `deviceId` and expose the resolved `device.id` ([#257](https://github.com/mobile-next/mobilewright/pull/257))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+* Feat: accept driver instances instead of `{type, ...}` config objects ([#260](https://github.com/mobile-next/mobilewright/pull/260)); legacy config objects are converted automatically with a deprecation warning ([#267](https://github.com/mobile-next/mobilewright/pull/267))
+* Feat: drivers can observe the test run via `TestObserver` lifecycle hooks (`onRunStart`, `onTestEnd`, `onRunEnd`) — mobilenext test-result upload happens automatically again, no reporter configuration needed ([#267](https://github.com/mobile-next/mobilewright/pull/267))
+* Feat: send mobilewright User-Agent header on fleet API requests ([#263](https://github.com/mobile-next/mobilewright/pull/263))
+* Fix: screen and device actions (`screenshot`, `swipe`, `launchApp`, `terminateApp`, …) now appear as steps in the test report ([#267](https://github.com/mobile-next/mobilewright/pull/267))
+* Refactor: split the driver contract into `DeviceAllocator` and `MobilewrightSession` interfaces ([#267](https://github.com/mobile-next/mobilewright/pull/267))
+* Chore: update packages ([#261](https://github.com/mobile-next/mobilewright/pull/261))
+
 ## [0.0.52] (2026-08-01)
 * Feat: add per-project `deviceId` and expose the resolved `device.id` ([#257](https://github.com/mobile-next/mobilewright/pull/257))
 * Feat(driver-mobilecli): surface selected, checked, and focused state from UI dumps ([#252](https://github.com/mobile-next/mobilewright/pull/252), [mobilecli#320](https://github.com/mobile-next/mobilecli/pull/320)), thanks to [@sjy](https://github.com/sjy)


### PR DESCRIPTION
Adds an `[Unreleased]` section to CHANGELOG.md covering #260, #261, #263, and #267 (driver instances + legacy conversion, TestObserver hooks with automatic mobilenext upload, User-Agent header, step reporting for screen/device actions, DeviceAllocator/MobilewrightSession split). Release date intentionally left unset.