### PR TITLE
fix(driver-mobilecli): pin mobilecli to published version ^0.3.88

### DIFF
--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@mobilewright/protocol": "^0.0.1",
     "debug": "^4.4.3",
-    "mobilecli": "1.0.0",
+    "mobilecli": "^0.3.88",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PR #258 bumped mobilecli to 1.0.0, but this version was never published to npm (latest is 0.3.88). This causes npm install to fail with ETARGET.