### PR TITLE
chore: bump mobilecli to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,6 +1152,84 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@mobilenext/mobilecli-darwin-amd64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-darwin-amd64/-/mobilecli-darwin-amd64-1.0.7.tgz",
+      "integrity": "sha512-v0ZuEJuZBLSLUMBg3a2dQ6Kf+AlrHTVqR5Dd1iRdaex3AiQ28aLdwf8XfOehleOrqM8g3EW2qZdaW4GIgt+csg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@mobilenext/mobilecli-darwin-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-darwin-arm64/-/mobilecli-darwin-arm64-1.0.7.tgz",
+      "integrity": "sha512-DLpinZGXmiZR9+L8UFxDo29W6oVG9QtuGtAYyRAjkGUMDnxGAyRCyttEdeU2U+q89dZ/Mq0+/I5hetKjOL6SzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@mobilenext/mobilecli-linux-amd64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-linux-amd64/-/mobilecli-linux-amd64-1.0.7.tgz",
+      "integrity": "sha512-ClCJRxuhl5yC61z48iVBWJ57gECSeW8fSwu/0yq2Idh4xA9o/fOIwCU2E9bm0JT3pDx9huxSqyuH45js1cm8hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mobilenext/mobilecli-linux-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-linux-arm64/-/mobilecli-linux-arm64-1.0.7.tgz",
+      "integrity": "sha512-KdnfJ1YnzvrP6v/L7OIVo4tWPaET0jzS3HwI4NJvolCHG08ZX2u541ps+xuJCPNTxwOpUt4O8Vswu3hAR9zaWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mobilenext/mobilecli-windows-amd64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-windows-amd64/-/mobilecli-windows-amd64-1.0.7.tgz",
+      "integrity": "sha512-VvQOfxpmogOAmO5cXkXwMlavAJXqencPZYD1s7cYdhewpP5SMTcafp/n2TUoBda3cJOCTK+ATehBB5UpoRdbQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@mobilenext/mobilecli-windows-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-windows-arm64/-/mobilecli-windows-arm64-1.0.7.tgz",
+      "integrity": "sha512-E6FrUFBISpRQ4afIiLQX3R/P3FhH+5vkSUYuOt4cd0eX70tXbWl0qTFcMlOaI6wI6LAgKxTOOjMnpyj11FBhGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@mobilewright/core": {
       "resolved": "packages/mobilewright-core",
       "link": true
@@ -2795,12 +2873,20 @@
       }
     },
     "node_modules/mobilecli": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-1.0.0.tgz",
-      "integrity": "sha512-oqzOzEXUwAQR1Xye2ouxdgrb3XFTfu8qBdWbWu4yuZ6DLi2aBWQ5mk8M0+9rDzd/X300KlZw83ghjp1ldzuqbQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-1.0.7.tgz",
+      "integrity": "sha512-PGvWzReJNPLcCfosVuvEidSyxWWd3FsQVKhWxVBkS0ywPRPSJaBvloFe+Nuxt8ILtGkbRVRG0+VRIbdIcz+Gng==",
       "license": "MIT",
       "bin": {
         "mobilecli": "index.js"
+      },
+      "optionalDependencies": {
+        "@mobilenext/mobilecli-darwin-amd64": "1.0.7",
+        "@mobilenext/mobilecli-darwin-arm64": "1.0.7",
+        "@mobilenext/mobilecli-linux-amd64": "1.0.7",
+        "@mobilenext/mobilecli-linux-arm64": "1.0.7",
+        "@mobilenext/mobilecli-windows-amd64": "1.0.7",
+        "@mobilenext/mobilecli-windows-arm64": "1.0.7"
       }
     },
     "node_modules/mobilewright": {
@@ -3599,7 +3685,7 @@
       "dependencies": {
         "@mobilewright/protocol": "^0.0.1",
         "debug": "^4.4.3",
-        "mobilecli": "1.0.0",
+        "mobilecli": "1.0.7",
         "ws": "^8.18.0"
       },
       "devDependencies": {

--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@mobilewright/protocol": "^0.0.1",
     "debug": "^4.4.3",
-    "mobilecli": "1.0.0",
+    "mobilecli": "1.0.7",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the mobilecli dependency in driver-mobilecli from 1.0.0 to 1.0.7, including the per-platform binary packages in the lockfile.