### PR TITLE
feat: add radio role mapping to query engine

### DIFF
--- a/packages/mobilewright-core/src/query-engine.ts
+++ b/packages/mobilewright-core/src/query-engine.ts
@@ -189,6 +189,7 @@ export const ROLE_TYPE_MAP = {
   image: ['image', 'imageview', 'appcompatimageview', 'shapeableimageview', 'reactimageview'],
   switch: ['switch', 'toggle', 'togglebutton'],
   checkbox: ['checkbox'],
+  radio: ['radio', 'radiobutton', 'appcompatradiobutton'],
   slider: ['slider', 'seekbar'],
   list: ['table', 'collectionview', 'listview', 'recyclerview', 'scrollview', 'reactscrollview'],
   listitem: ['cell', 'linearlayout', 'relativelayout', 'other'],


### PR DESCRIPTION
Adds a `radio` entry to `ROLE_TYPE_MAP` so `getByRole('radio')` matches radio, radiobutton, and appcompatradiobutton elements.