### PR TITLE
docs: add radio role to locators guide

### DIFF
--- a/docs/src/guides/locators.md
+++ b/docs/src/guides/locators.md
@@ -39,6 +39,7 @@ the app uses `AppCompatEditText`).
 | `android.widget.Switch` | `switch` |
 | `android.widget.ToggleButton` | `switch` |
 | `android.widget.CheckBox` | `checkbox` |
+| `android.widget.RadioButton` | `radio` |
 | `android.widget.SeekBar` | `slider` |
 | `android.widget.ListView` | `list` |
 | `androidx.recyclerview.widget.RecyclerView` | `list` |
@@ -57,6 +58,7 @@ of the collapsed framework class above — these are also recognized:
 | `androidx.appcompat.widget.AppCompatButton` | `button` |
 | `com.google.android.material.button.MaterialButton` | `button` |
 | `com.google.android.material.floatingactionbutton.FloatingActionButton` | `button` |
+| `androidx.appcompat.widget.AppCompatRadioButton` | `radio` |
 | `androidx.appcompat.widget.AppCompatEditText` | `textfield` |
 | `com.google.android.material.textfield.TextInputEditText` | `textfield` |
 | `androidx.appcompat.widget.AppCompatTextView` | `text` |
@@ -101,8 +103,8 @@ of the collapsed framework class above — these are also recognized:
 
 - **Classes with no role.** Anything not listed above has no role mapping —
   `getByRole()` won't find it. Target it with `getByType('<raw.native.Class>')`,
-  `getByLabel()`, or `getByTestId()`. Examples: Android `Spinner`, `RadioButton`,
-  `RadioGroup`, `CheckedTextView`; iOS `Picker`, `DatePicker`.
+  `getByLabel()`, or `getByTestId()`. Examples: Android `Spinner`, `RadioGroup`,
+  `CheckedTextView`; iOS `Picker`, `DatePicker`.
 
 - **iOS source filtering.** mobilecli currently surfaces only a subset of iOS
   classes — `Button`, `TextField`, `SecureTextField`, `SearchField`, `Switch`,


### PR DESCRIPTION
Follow-up to #277: documents the new `radio` role mapping (RadioButton / AppCompatRadioButton) in the locators guide and removes RadioButton from the unmapped-classes note.