### PR TITLE
feat: add device.setGeolocation for overriding device GPS location

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ console.log(device.id);
 await device.setOrientation('landscape');
 const orientation = await device.getOrientation();
 
+// Geolocation — override the GPS location the device reports
+await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+await device.setGeolocation(null); // clear the override
+
 // Screen dimensions and pixel density: { width, height, scale }
 const size = await device.screenSize();
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ This is a living document of planned and in-progress features. Items are roughly
 | ✅ Locator assertions | `toBeVisible()`, `toBeEnabled()`, `toBeChecked()`, `toBeHidden()`, `toHaveText()`, `toHaveValue()` |
 | ✅ Value assertions | `toBe()`, `toEqual()`, `toContain()`, `toBeGreaterThan()`, `toMatch()` |
 | ✅ App lifecycle | `launchApp()`, `terminateApp()`, `installApp()`, `uninstallApp()` |
-| ✅ Device control | `setOrientation()`, `openUrl()`, `listApps()`, `getForegroundApp()` |
+| ✅ Device control | `setOrientation()`, `setGeolocation()`, `openUrl()`, `listApps()`, `getForegroundApp()` |
 | ✅ Video recording | Attached to the HTML report (`on`, `on failure`, `off`) |
 | ✅ WebView support | `getByWebView().getByRole('button')` — full locator API inside WebViews |
 | ✅ Multi-project config | `projects: [{ name: 'iPhone', use: { platform: 'ios' } }, ...]` |
@@ -39,7 +39,7 @@ This is a living document of planned and in-progress features. Items are roughly
 | **Network Capture** | Record `.har` files and inspect HTTP/HTTPS traffic during test runs. | Planned |
 | **Network Interception** | Stub, modify, or block HTTP/HTTPS requests in flight to test error states and offline behavior without a live backend. | Planned |
 | **Network Conditioning** | Simulate throttled or degraded networks — 3G, edge, high latency, packet loss, or fully offline — to test loading states and retry behavior. | Planned |
-| **GPS Location Simulation** | Set the device's reported location, or replay a route of coordinates, to test location-aware flows. | Planned |
+| **GPS Route Replay** | Replay a route of coordinates to test location-aware flows. Setting a fixed location shipped as `device.setGeolocation()`. | Planned |
 | **Device Settings** | Prepare device system settings before a test — dark mode, high contrast, font size, locale, and permissions. | Planned |
 | **Timezone** | Set the device timezone before a test run, to verify date/time rendering and timezone-dependent logic. | Planned |
 | **Shake Gesture** | Trigger a device shake from a test, for apps that use it for undo, bug reporting, or debug menus. | Planned |

--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -11,6 +11,7 @@ import type {
   DeviceSettings,
   DeviceState,
   DeviceType,
+  Geolocation,
   GestureSequence,
   HardwareButton,
   LaunchOptions,
@@ -561,6 +562,14 @@ export class MobilecliDriver implements MobilewrightSession, DeviceAllocator {
 
   async setOrientation(orientation: Orientation): Promise<void> {
     await this.call('device.io.orientation.set', { orientation });
+  }
+
+  async setGeolocation(geolocation: Geolocation | null): Promise<void> {
+    if (geolocation === null) {
+      await this.call('device.location.clear');
+      return;
+    }
+    await this.call('device.location.set', { latitude: geolocation.latitude, longitude: geolocation.longitude });
   }
 
   // ─── Recording Operations ─────────────────────────────────────

--- a/packages/driver-mobilenext/src/driver.ts
+++ b/packages/driver-mobilenext/src/driver.ts
@@ -11,6 +11,7 @@ import type {
   DeviceInfo,
   DeviceState,
   DeviceType,
+  Geolocation,
   GestureSequence,
   HardwareButton,
   LaunchOptions,
@@ -374,6 +375,14 @@ export class MobileNextDriver implements MobilewrightSession, DeviceAllocator {
 
   async setOrientation(orientation: Orientation): Promise<void> {
     await this.call('device.io.orientation.set', { orientation });
+  }
+
+  async setGeolocation(geolocation: Geolocation | null): Promise<void> {
+    if (geolocation === null) {
+      await this.call('device.location.clear');
+      return;
+    }
+    await this.call('device.location.set', { latitude: geolocation.latitude, longitude: geolocation.longitude });
   }
 
   // ─── Recording ──────────────────────────────────────────────

--- a/packages/mobilewright-core/src/device.test.ts
+++ b/packages/mobilewright-core/src/device.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import type {
+  Geolocation,
   MobilewrightDriver,
   Orientation,
   AppInfo,
@@ -26,6 +27,7 @@ function createMockDriver(screenSize: ScreenSize): MobilewrightDriver {
     getScreenSize: async () => screenSize,
     getOrientation: async () => 'portrait' as Orientation,
     setOrientation: async () => {},
+    setGeolocation: async () => {},
     launchApp: async () => {},
     terminateApp: async () => {},
     listApps: async () => [] as AppInfo[],
@@ -93,6 +95,62 @@ test.describe('Device.id', () => {
   });
 });
 
+test.describe('Device.setGeolocation', () => {
+  function createGeolocationRecordingDriver(): { driver: MobilewrightDriver; calls: Array<Geolocation | null> } {
+    const driver = createMockDriver({ width: 390, height: 844, scale: 3 });
+    const calls: Array<Geolocation | null> = [];
+    driver.setGeolocation = async (geolocation) => {
+      calls.push(geolocation);
+    };
+    return { driver, calls };
+  }
+
+  test('passes the coordinates to the driver', async () => {
+    const { driver, calls } = createGeolocationRecordingDriver();
+    const device = new Device(driver);
+
+    await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+
+    expect(calls).toEqual([{ latitude: -17.833, longitude: 177.947 }]);
+  });
+
+  test('clears the override when called with null', async () => {
+    const { driver, calls } = createGeolocationRecordingDriver();
+    const device = new Device(driver);
+
+    await device.setGeolocation(null);
+
+    expect(calls).toEqual([null]);
+  });
+
+  test('clears the override when called with no arguments', async () => {
+    const { driver, calls } = createGeolocationRecordingDriver();
+    const device = new Device(driver);
+
+    await device.setGeolocation();
+
+    expect(calls).toEqual([null]);
+  });
+
+  test('throws when latitude is out of range', async () => {
+    const { driver, calls } = createGeolocationRecordingDriver();
+    const device = new Device(driver);
+
+    await expect(device.setGeolocation({ latitude: 90.1, longitude: 0 })).rejects.toThrow(/latitude/);
+    await expect(device.setGeolocation({ latitude: -90.1, longitude: 0 })).rejects.toThrow(/latitude/);
+    expect(calls).toEqual([]);
+  });
+
+  test('throws when longitude is out of range', async () => {
+    const { driver, calls } = createGeolocationRecordingDriver();
+    const device = new Device(driver);
+
+    await expect(device.setGeolocation({ latitude: 0, longitude: 180.1 })).rejects.toThrow(/longitude/);
+    await expect(device.setGeolocation({ latitude: 0, longitude: -180.1 })).rejects.toThrow(/longitude/);
+    expect(calls).toEqual([]);
+  });
+});
+
 test.describe('Device step reporting', () => {
   function createRecordingStepFn(titles: string[]) {
     return (title: string, fn: () => Promise<unknown>) => {
@@ -113,6 +171,7 @@ test.describe('Device step reporting', () => {
     await device.uninstallApp('com.test');
     await device.openUrl('https://example.com');
     await device.setOrientation('landscape');
+    await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
 
     expect(titles).toEqual([
       'device.launchApp()',
@@ -121,6 +180,7 @@ test.describe('Device step reporting', () => {
       'device.uninstallApp()',
       'device.openUrl()',
       'device.setOrientation()',
+      'device.setGeolocation()',
     ]);
   });
 

--- a/packages/mobilewright-core/src/device.ts
+++ b/packages/mobilewright-core/src/device.ts
@@ -3,6 +3,7 @@ import type {
   AppInfo,
   ConnectionConfig,
   DeviceSettings,
+  Geolocation,
   LaunchOptions,
   MobilewrightDriver,
   Orientation,
@@ -116,6 +117,22 @@ export class Device {
 
   async setOrientation(orientation: Orientation): Promise<void> {
     return this._step('device.setOrientation()', () => this.driver.setOrientation(orientation));
+  }
+
+  /**
+   * Override the GPS location reported by the device.
+   * Passing null or undefined clears the override — matches Playwright's setGeolocation().
+   */
+  async setGeolocation(geolocation?: Geolocation | null): Promise<void> {
+    if (geolocation !== undefined && geolocation !== null) {
+      if (geolocation.latitude < -90 || geolocation.latitude > 90) {
+        throw new Error(`setGeolocation: latitude must be between -90 and 90, got ${geolocation.latitude}`);
+      }
+      if (geolocation.longitude < -180 || geolocation.longitude > 180) {
+        throw new Error(`setGeolocation: longitude must be between -180 and 180, got ${geolocation.longitude}`);
+      }
+    }
+    return this._step('device.setGeolocation()', () => this.driver.setGeolocation(geolocation ?? null));
   }
 
   /** Screen dimensions and pixel density: { width, height, scale }. */

--- a/packages/mobilewright-core/src/expect.test.ts
+++ b/packages/mobilewright-core/src/expect.test.ts
@@ -75,6 +75,7 @@ function createMockDriver(hierarchy: ViewNode[]): MobilewrightDriver & { _tracke
     getScreenSize: async () => ({ width: 390, height: 844, scale: 3 }),
     getOrientation: async () => 'portrait' as Orientation,
     setOrientation: async (...args: any[]) => { tracker.setOrientationCalls.push(args); },
+    setGeolocation: async () => {},
     launchApp: async (...args: any[]) => { tracker.launchAppCalls.push(args); },
     terminateApp: async (...args: any[]) => { tracker.terminateAppCalls.push(args); },
     listApps: async () => [] as AppInfo[],

--- a/packages/mobilewright-core/src/locator.test.ts
+++ b/packages/mobilewright-core/src/locator.test.ts
@@ -78,6 +78,7 @@ function createMockDriver(hierarchy: ViewNode[]): MobilewrightDriver & { _tracke
     getScreenSize: async () => ({ width: 390, height: 844, scale: 3 }),
     getOrientation: async () => 'portrait' as Orientation,
     setOrientation: async (...args: any[]) => { tracker.setOrientationCalls.push(args); },
+    setGeolocation: async () => {},
     launchApp: async (...args: any[]) => { tracker.launchAppCalls.push(args); },
     terminateApp: async (...args: any[]) => { tracker.terminateAppCalls.push(args); },
     listApps: async () => [] as AppInfo[],

--- a/packages/mobilewright-core/src/screen.test.ts
+++ b/packages/mobilewright-core/src/screen.test.ts
@@ -41,6 +41,7 @@ function createMockDriver(): MobilewrightDriver & { _tracker: CallTracker } {
     getScreenSize: async () => ({ width: 390, height: 844, scale: 3 }),
     getOrientation: async () => 'portrait' as Orientation,
     setOrientation: async () => {},
+    setGeolocation: async () => {},
     launchApp: async () => {},
     terminateApp: async () => {},
     listApps: async () => [] as AppInfo[],

--- a/packages/protocol/src/driver.ts
+++ b/packages/protocol/src/driver.ts
@@ -4,6 +4,7 @@ import type {
   DeviceInfo,
   DeviceSettings,
   DeviceType,
+  Geolocation,
   GestureSequence,
   HardwareButton,
   LaunchOptions,
@@ -166,6 +167,8 @@ export interface MobilewrightSession {
   getOrientation(): Promise<Orientation>;
   /** Rotate the device to the given orientation. */
   setOrientation(orientation: Orientation): Promise<void>;
+  /** Override the GPS location reported by the device; null clears the override. */
+  setGeolocation(geolocation: Geolocation | null): Promise<void>;
 
   // Apps
   /** Launch the app with the given bundle id, optionally with launch options. */

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -36,6 +36,13 @@ export type Platform = 'ios' | 'android';
 export type DeviceType = 'real' | 'simulator' | 'emulator';
 export type DeviceState = 'online' | 'offline';
 
+export interface Geolocation {
+  /** Latitude in degrees, between -90 and 90. */
+  latitude: number;
+  /** Longitude in degrees, between -180 and 180. */
+  longitude: number;
+}
+
 export interface DeviceInfo {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- Adds `device.setGeolocation({ latitude, longitude })`, mirroring Playwright's `setGeolocation` API
- Passing `null` or calling with no arguments clears the override
- Validates latitude (-90..90) and longitude (-180..180) before calling the driver
- Both drivers map to the `device.location.set` / `device.location.clear` RPC methods (mobilecli 1.0.7+)
- Reported as a `device.setGeolocation()` test step

## Test plan
- [x] Unit tests: coordinates forwarded to driver, null/undefined clears, out-of-range values throw, step title recorded
- [x] `npm run build` and full test suite pass (602 tests)