### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released version of `mobilewright`.
+
+| Version        | Supported |
+| -------------- | --------- |
+| Latest release | ✅        |
+| Older releases | ❌        |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/mobile-next/mobilewright/security/advisories/new).
+Do not open a public issue or pull request for an undisclosed vulnerability.
+
+Include the affected version, impact, reproduction steps, and any suggested fix. Never include real
+credentials or personal data; use clearly fake values in examples.
+
+We aim to acknowledge reports within three business days and provide a status update within seven
+days. We will confirm whether the report is accepted or declined and coordinate any fix and public
+disclosure with the reporter.


### PR DESCRIPTION
Adds a security policy: latest release supported, private reporting via GitHub Security Advisories, response timelines (ack within 3 business days, status within 7 days).