### PR TITLE
fix: resolve mobilecli binary from per-platform optional dependency

### DIFF
--- a/packages/driver-mobilecli/src/resolve-binary.test.ts
+++ b/packages/driver-mobilecli/src/resolve-binary.test.ts
@@ -1,51 +1,58 @@
+import { existsSync } from 'node:fs';
 import { test, expect } from '@playwright/test';
-import { resolveMobilecliBinary } from './resolve-binary.js';
+import { getPlatformBinary, resolveMobilecliBinary } from './resolve-binary.js';
 
-function simulatePlatform(platform: string, arch: string, fn: () => void): void {
-  const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
-  const archDescriptor = Object.getOwnPropertyDescriptor(process, 'arch')!;
-  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
-  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
-  try {
-    fn();
-  } finally {
-    Object.defineProperty(process, 'platform', platformDescriptor);
-    Object.defineProperty(process, 'arch', archDescriptor);
-  }
-}
-
-test('resolveMobilecliBinary returns a path to the darwin-arm64 binary', () => {
-  simulatePlatform('darwin', 'arm64', () => {
-    expect(resolveMobilecliBinary()).toContain('mobilecli-darwin-arm64');
+test('darwin-arm64 maps to the @mobilenext darwin-arm64 package', () => {
+  expect(getPlatformBinary('darwin', 'arm64')).toEqual({
+    packageName: '@mobilenext/mobilecli-darwin-arm64',
+    binaryName: 'mobilecli-darwin-arm64',
   });
 });
 
-test('resolveMobilecliBinary returns a path to the darwin-amd64 binary for x64', () => {
-  simulatePlatform('darwin', 'x64', () => {
-    expect(resolveMobilecliBinary()).toContain('mobilecli-darwin-amd64');
+test('darwin-x64 maps to the @mobilenext darwin-amd64 package', () => {
+  expect(getPlatformBinary('darwin', 'x64')).toEqual({
+    packageName: '@mobilenext/mobilecli-darwin-amd64',
+    binaryName: 'mobilecli-darwin-amd64',
   });
 });
 
-test('resolveMobilecliBinary returns a path to the linux-arm64 binary', () => {
-  simulatePlatform('linux', 'arm64', () => {
-    expect(resolveMobilecliBinary()).toContain('mobilecli-linux-arm64');
+test('linux-arm64 maps to the @mobilenext linux-arm64 package', () => {
+  expect(getPlatformBinary('linux', 'arm64')).toEqual({
+    packageName: '@mobilenext/mobilecli-linux-arm64',
+    binaryName: 'mobilecli-linux-arm64',
   });
 });
 
-test('resolveMobilecliBinary returns a path to the linux-amd64 binary for x64', () => {
-  simulatePlatform('linux', 'x64', () => {
-    expect(resolveMobilecliBinary()).toContain('mobilecli-linux-amd64');
+test('linux-x64 maps to the @mobilenext linux-amd64 package', () => {
+  expect(getPlatformBinary('linux', 'x64')).toEqual({
+    packageName: '@mobilenext/mobilecli-linux-amd64',
+    binaryName: 'mobilecli-linux-amd64',
   });
 });
 
-test('resolveMobilecliBinary returns a path to the windows-amd64 binary for win32-x64', () => {
-  simulatePlatform('win32', 'x64', () => {
-    expect(resolveMobilecliBinary()).toContain('mobilecli-windows-amd64.exe');
+test('win32-x64 maps to the @mobilenext windows-amd64 package with an .exe binary', () => {
+  expect(getPlatformBinary('win32', 'x64')).toEqual({
+    packageName: '@mobilenext/mobilecli-windows-amd64',
+    binaryName: 'mobilecli-windows-amd64.exe',
   });
 });
 
-test('resolveMobilecliBinary throws an error for an unsupported platform', () => {
-  simulatePlatform('freebsd', 'x64', () => {
-    expect(() => resolveMobilecliBinary()).toThrow('Unsupported platform: freebsd-x64');
+test('win32-arm64 maps to the @mobilenext windows-arm64 package with an .exe binary', () => {
+  expect(getPlatformBinary('win32', 'arm64')).toEqual({
+    packageName: '@mobilenext/mobilecli-windows-arm64',
+    binaryName: 'mobilecli-windows-arm64.exe',
   });
+});
+
+test('an unsupported platform throws an error', () => {
+  expect(() => getPlatformBinary('freebsd', 'x64')).toThrow('Unsupported platform: freebsd-x64');
+});
+
+test('an explicit path is returned as-is', () => {
+  expect(resolveMobilecliBinary('/opt/bin/mobilecli')).toBe('/opt/bin/mobilecli');
+});
+
+test('the resolved binary for this machine exists on disk', () => {
+  const binaryPath = resolveMobilecliBinary();
+  expect(existsSync(binaryPath)).toBe(true);
 });

--- a/packages/driver-mobilecli/src/resolve-binary.ts
+++ b/packages/driver-mobilecli/src/resolve-binary.ts
@@ -1,9 +1,51 @@
 import { join, dirname } from 'node:path';
 import { createRequire } from 'node:module';
 
+interface PlatformBinary {
+  packageName: string;
+  binaryName: string;
+}
+
+/**
+ * Map a platform/arch pair to the @mobilenext platform package that ships
+ * the mobilecli binary, and the binary's file name inside that package.
+ */
+export function getPlatformBinary(platform: string, arch: string): PlatformBinary {
+  let name: string;
+  switch (`${platform}-${arch}`) {
+    case 'darwin-arm64':
+      name = 'mobilecli-darwin-arm64';
+      break;
+    case 'darwin-x64':
+      name = 'mobilecli-darwin-amd64';
+      break;
+    case 'linux-arm64':
+      name = 'mobilecli-linux-arm64';
+      break;
+    case 'linux-x64':
+      name = 'mobilecli-linux-amd64';
+      break;
+    case 'win32-arm64':
+      name = 'mobilecli-windows-arm64';
+      break;
+    case 'win32-x64':
+      name = 'mobilecli-windows-amd64';
+      break;
+    default:
+      throw new Error(`Unsupported platform: ${platform}-${arch}`);
+  }
+
+  return {
+    packageName: `@mobilenext/${name}`,
+    binaryName: platform === 'win32' ? `${name}.exe` : name,
+  };
+}
+
 /**
  * Resolve the mobilecli binary using Node's module resolution so it works
- * from npx caches, global installs, and local node_modules alike.
+ * from npx caches, global installs, and local node_modules alike. The binary
+ * ships in a per-platform optionalDependency of mobilecli, so it is resolved
+ * from mobilecli's own location.
  *
  * @param explicitPath Use this path directly instead of resolving one.
  */
@@ -12,28 +54,17 @@ export function resolveMobilecliBinary(explicitPath?: string): string {
     return explicitPath;
   }
 
-  let binary: string;
-  switch (`${process.platform}-${process.arch}`) {
-    case 'darwin-arm64':
-      binary = 'mobilecli-darwin-arm64';
-      break;
-    case 'darwin-x64':
-      binary = 'mobilecli-darwin-amd64';
-      break;
-    case 'linux-arm64':
-      binary = 'mobilecli-linux-arm64';
-      break;
-    case 'linux-x64':
-      binary = 'mobilecli-linux-amd64';
-      break;
-    case 'win32-x64':
-      binary = 'mobilecli-windows-amd64.exe';
-      break;
-    default:
-      throw new Error(`Unsupported platform: ${process.platform}-${process.arch}`);
+  const { packageName, binaryName } = getPlatformBinary(process.platform, process.arch);
+  const _require = createRequire(import.meta.url);
+  const mobilecliPkg = _require.resolve('mobilecli/package.json');
+  const requireFromMobilecli = createRequire(mobilecliPkg);
+
+  let platformPkg: string;
+  try {
+    platformPkg = requireFromMobilecli.resolve(`${packageName}/package.json`);
+  } catch {
+    throw new Error(`Failed to find ${packageName}. Please reinstall mobilecli.`);
   }
 
-  const _require = createRequire(import.meta.url);
-  const pkgJson = _require.resolve('mobilecli/package.json');
-  return join(dirname(pkgJson), 'bin', binary);
+  return join(dirname(platformPkg), binaryName);
 }


### PR DESCRIPTION
Since mobilecli 1.0.7 the binaries ship in per-platform optional dependencies (`@mobilenext/mobilecli-<platform>-<arch>`) instead of `mobilecli/bin`. Update `resolveMobilecliBinary` to resolve the platform package from mobilecli's own location, add win32-arm64 support, and fail with a clear reinstall message when the platform package is missing.
