### PR TITLE
docs: add Cloud Providers section with Mobile Next Cloud and BrowserStack guides

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -46,6 +46,16 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Cloud Providers',
+      collapsed: false,
+      items: [
+        'cloud-providers/index',
+        'cloud-providers/mobile-next-cloud',
+        'cloud-providers/browserstack',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Integrations',
       collapsed: false,
       items: [

--- a/docs/src/cloud-providers/_category_.json
+++ b/docs/src/cloud-providers/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Cloud Providers",
+  "position": 4,
+  "collapsed": false
+}

--- a/docs/src/cloud-providers/browserstack.md
+++ b/docs/src/cloud-providers/browserstack.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 3
+title: BrowserStack
+---
+
+# BrowserStack
+
+[BrowserStack App Automate](https://www.browserstack.com/app-automate) runs Mobilewright tests
+on real devices through the
+[`@browserstack/mobilewright`](https://www.npmjs.com/package/@browserstack/mobilewright) driver,
+maintained by BrowserStack. Every test session is a first-class App Automate session — dashboard,
+server-side video, device and network logs — with no BrowserStack-specific code in your tests.
+
+Requires `mobilewright` ≥ 0.0.53.
+
+## Setup
+
+### 1. Install the driver
+
+```bash
+npm install --save-dev @browserstack/mobilewright
+```
+
+### 2. Set your credentials
+
+Find your username and access key in the
+[BrowserStack account settings](https://www.browserstack.com/accounts/profile/details) and
+export them:
+
+```bash
+export BROWSERSTACK_USERNAME=...
+export BROWSERSTACK_ACCESS_KEY=...
+```
+
+### 3. Set the driver
+
+```ts
+// mobilewright.config.ts
+import { defineConfig } from 'mobilewright';
+import { browserStackDriver } from '@browserstack/mobilewright';
+
+export default defineConfig({
+  testDir: './tests',
+  bundleId: 'com.example.app',
+  driver: browserStackDriver({
+    app: 'bs://<app-id>', // or a local .apk/.ipa path, or an https:// url — uploaded for you
+    project: 'My project',
+  }),
+  projects: [
+    { name: 'android', use: { platform: 'android', deviceName: /Google Pixel 8\b/ } },
+    { name: 'ios', use: { platform: 'ios', deviceType: 'real', osVersion: '>=17 <19' } },
+  ],
+});
+```
+
+Device selection uses the standard config fields: `deviceName` (regex), `osVersion` (range
+expressions like `">=17 <19"`), and `deviceType` (App Automate is always `real`). The app falls
+back to the `BROWSERSTACK_APP` env var when `app` is omitted.
+
+Session names and statuses are automatic: at run end every App Automate session is named after
+the tests it ran, marked passed or failed, and its dashboard link is printed.
+
+## Switching between a local device and BrowserStack
+
+Keep one config and pick the driver by environment: local (mobilecli) by default, BrowserStack
+when credentials are present.
+
+```ts
+import { defineConfig, type MobilewrightConfig } from 'mobilewright';
+import { browserStackDriver } from '@browserstack/mobilewright';
+
+const config: MobilewrightConfig = { /* ...your existing config... */ };
+
+if (process.env.BROWSERSTACK_USERNAME) {
+  config.driver = browserStackDriver({ app: './build/app.apk' });
+}
+
+export default defineConfig(config);
+```
+
+```bash
+npx mobilewright test                                     # local device
+BROWSERSTACK_USERNAME=... BROWSERSTACK_ACCESS_KEY=... \
+  npx mobilewright test                                   # the same suite on App Automate
+```
+
+Local `.apk`/`.ipa` paths are uploaded automatically, once per run.
+
+## Learn more
+
+BrowserStack Local, geolocation and network simulation, camera and biometric injection, and
+other App Automate features are documented in the
+[`@browserstack/mobilewright` package on npm](https://www.npmjs.com/package/@browserstack/mobilewright).

--- a/docs/src/cloud-providers/index.md
+++ b/docs/src/cloud-providers/index.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 1
+title: Overview
+---
+
+# Cloud Providers
+
+Mobilewright runs the same tests on a phone plugged into your laptop and on real devices in the
+cloud. The only thing that changes is the `driver` in `mobilewright.config.ts` — your tests,
+locators, and fixtures stay exactly as they are.
+
+Cloud devices let you scale up fast: instead of maintaining a device lab, raise `workers` and
+let the provider allocate one device per worker. A suite that takes an hour on a single device
+finishes in minutes across a fleet, and CI no longer depends on hardware sitting under a desk.
+
+Mobilewright supports these providers:
+
+- [Mobile Next Cloud](./mobile-next-cloud.md) — the driver maintained by the Mobilewright team, with test results uploaded to your dashboard automatically.
+- [BrowserStack](./browserstack.md) — App Automate sessions via the `@browserstack/mobilewright` driver.
+
+A common pattern is to keep one config and switch drivers by environment: local device by
+default, cloud when credentials are present. Each provider page shows how.

--- a/docs/src/cloud-providers/mobile-next-cloud.md
+++ b/docs/src/cloud-providers/mobile-next-cloud.md
@@ -1,0 +1,96 @@
+---
+sidebar_position: 2
+title: Mobile Next Cloud
+---
+
+# Mobile Next Cloud
+
+[Mobile Next Cloud](https://mobilenext.ai/cloud?utm_source=docs&utm_medium=docs&utm_campaign=mobilewright&utm_content=cloud-providers)
+gives you API access to hundreds of real Android and iOS devices. Mobilewright allocates one
+device per worker, runs your tests, and uploads the results to your dashboard — no reporter
+configuration needed.
+
+## Setup
+
+The driver ships with Mobilewright — nothing extra to install.
+
+### 1. Get an API key
+
+Sign in at [mobilenext.ai](https://mobilenext.ai/cloud?utm_source=docs&utm_medium=docs&utm_campaign=mobilewright&utm_content=cloud-providers-api-key),
+create an API key, and export it:
+
+```bash
+export MOBILENEXT_API_KEY=...
+```
+
+### 2. Set the driver
+
+```ts
+// mobilewright.config.ts
+import { defineConfig } from 'mobilewright';
+import { MobileNextDriver } from '@mobilewright/driver-mobilenext';
+
+export default defineConfig({
+  testDir: './tests',
+  bundleId: 'com.example.app',
+  driver: new MobileNextDriver({
+    apiKey: process.env.MOBILENEXT_API_KEY,
+  }),
+  projects: [
+    {
+      name: 'ios',
+      use: { platform: 'ios', deviceType: 'real', osVersion: '>=18', installApps: ['./build/app.ipa'] },
+    },
+    {
+      name: 'android',
+      use: { platform: 'android', deviceType: 'real', installApps: ['./build/app.apk'] },
+    },
+  ],
+});
+```
+
+Device selection uses the standard config fields — `platform`, `deviceType`, `deviceName`,
+`osVersion` — see [Configuration](../test/configuration.md#driver) for the full list of driver
+options such as `allocationTimeout` and `uploadTimeout`.
+
+## Switching between a local device and the cloud
+
+Keep one config and pick the driver by environment: local (mobilecli) by default, Mobile Next
+Cloud when the API key is present.
+
+```ts
+import { defineConfig, type MobilewrightConfig } from 'mobilewright';
+import { MobileNextDriver } from '@mobilewright/driver-mobilenext';
+
+const config: MobilewrightConfig = {
+  testDir: './tests',
+  bundleId: 'com.example.app',
+  fullyParallel: true,
+  workers: process.env.CI ? 4 : 1,
+  projects: [
+    { name: 'ios', use: { platform: 'ios', deviceType: 'real', installApps: ['./build/app.ipa'] } },
+  ],
+};
+
+if (process.env.MOBILENEXT_API_KEY) {
+  config.driver = new MobileNextDriver({ apiKey: process.env.MOBILENEXT_API_KEY });
+}
+
+export default defineConfig(config);
+```
+
+```bash
+npx mobilewright test                              # local device
+MOBILENEXT_API_KEY=... npx mobilewright test       # the same suite on Mobile Next Cloud
+```
+
+## Test results
+
+With `MobileNextDriver`, the HTML report and test results are uploaded to mobilenext.ai after
+every run. Control this with the driver's `testResult` option — see
+[Reporting](../test/configuration.md#reporting).
+
+## Debugging
+
+Set `DEBUG=mw:driver-mobilenext` to log device allocation and connection details. See
+[Troubleshooting](../guides/troubleshooting.md).

--- a/docs/src/integrations/_category_.json
+++ b/docs/src/integrations/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Integrations",
-  "position": 4,
+  "position": 5,
   "collapsed": false
 }


### PR DESCRIPTION
## Summary
- New **Cloud Providers** sidebar category between Guides and Integrations
- Overview page: same tests run locally or on cloud devices, scale by swapping the `driver`
- **Mobile Next Cloud** page: API key, driver config, env-based local/cloud switch, results upload
- **BrowserStack** page: install `@browserstack/mobilewright`, credentials, `browserStackDriver` config, env switch, link to npm