### PR TITLE
docs: add Requirements to Installation and correct the scaffold walkthrough

### DIFF
--- a/docs/src/getting-started/intro.md
+++ b/docs/src/getting-started/intro.md
@@ -15,55 +15,139 @@ Mobilewright is an end-to-end testing framework for mobile applications. It prov
 - **TypeScript-first** — Full type safety and autocompletion
 - **Agent-ready** — Built for AI agent integration
 
-## Installing Mobilewright
+## Requirements
+
+Mobilewright drives real simulators, emulators and devices, so it needs a working mobile toolchain on your machine before the first test can run.
+
+**Everywhere**
+
+- Node.js 18 or newer.
+- A booted simulator or emulator, or a device connected over USB. Mobilewright does not start one for you.
+
+**For iOS**
+
+- macOS 13 or newer.
+- Xcode, plus the Xcode Command Line Tools.
+
+**For Android**
+
+- A JDK, version 11 or newer.
+- The Android SDK, with `ANDROID_HOME` set and `adb` on your `PATH`.
+- Works on macOS and Windows 11. On Linux, run Android tests through the [Docker image](../guides/docker.md).
+
+You do not need to install [mobilecli](https://github.com/mobile-next/mobilecli) — it ships with the `mobilewright` package as a per-platform binary.
+
+### Check your setup
+
+`mobilewright doctor` verifies all of the above and tells you how to fix whatever is missing. Run it before anything else:
 
 ```bash
-npm install mobilewright @mobilewright/test
+npx mobilewright doctor
 ```
 
-Initialize a new project:
+```
+mobilewright doctor  v0.0.1
+────────────────────────────────────────────────────────────
+
+  System
+    ✓  macOS  macOS 15.7.4  [Apple Silicon (arm64)]
+    ✓  Git  2.50.1 (Apple Git-155)
+    ✓  Node.js  v22.19.0
+    ✓  npm  10.9.3
+    ✓  mobilecli  mobilecli version 0.3.66
+    ✓  mobilecli devices  2 online devices
+       iPhone (00008030-000E1D892340802E)
+       iPhone 17 Pro (6A557392-1480-4355-9EBC-B1D12A0F665D)
+
+  iOS
+    ✓  Xcode  26.0.1 (17A400)
+    ✓  Xcode Command Line Tools  /Applications/Xcode.app/Contents/Developer
+    ✓  iOS Simulators  62 available, 2 booted
+
+  Android
+    ✓  Java (JDK)  21.0.10
+    ✓  ANDROID_HOME  /Users/john/Library/Android/sdk
+    ✓  ADB (Android Debug Bridge)  1.0.41
+    ✓  Android Emulator  36.1.9.0
+
+────────────────────────────────────────────────────────────
+  Summary  17 ok
+  ✓ Ready for mobile development!
+```
+
+Every failing check comes with the commands that resolve it. See [Troubleshooting](../guides/troubleshooting.md) for the full breakdown and for `--json` output.
+
+## Installing Mobilewright
+
+Scaffold a new project:
 
 ```bash
 npm init mobilewright@latest
 ```
 
-This creates the configuration file and an example test. If either file already exists, it will be skipped.
+This asks three questions — TypeScript or JavaScript, the directory to put tests in (default `tests`), and the bundle ID of the app under test — then writes the project files and runs `npm install` for you. If it finds an Xcode or Gradle project nearby it pre-fills the bundle ID.
+
+To add Mobilewright to a project that already has a `package.json`, install it directly instead:
+
+```bash
+npm install --save-dev mobilewright @mobilewright/test
+```
 
 ## Directory layout
 
-After initialization, your project will look like this:
+After scaffolding, your project looks like this:
 
 ```
 mobilewright.config.ts
 package.json
 package-lock.json
 tests/
-  example.test.ts
+  example.spec.ts
 ```
 
-The `mobilewright.config.ts` file defines your target platform, app bundle ID, and device:
+The generated `mobilewright.config.ts` is deliberately minimal:
 
 ```typescript
 import { defineConfig } from 'mobilewright';
 
 export default defineConfig({
-  platform: 'ios',
+  testDir: './tests',
   bundleId: 'com.example.myapp',
-  deviceName: /iPhone 16/,
-  installApps: './builds/myapp.ipa',
-  timeout: 10_000,
+  reporter: 'html',
 });
 ```
 
-The `tests/example.test.ts` file contains a starter test:
+And `tests/example.spec.ts` contains a starter test:
 
 ```typescript
 import { test, expect } from '@mobilewright/test';
 
-test('app launches and shows home screen', async ({ screen }) => {
+test('app launches and shows home screen', async ({ screen, device }) => {
   await expect(screen.getByText('Welcome')).toBeVisible();
 });
 ```
+
+This test asserts on the text `Welcome`, which almost certainly is not on your app's first screen — change it to something your app actually shows before running it.
+
+## Choosing a device and installing your app
+
+The scaffolded config does not pin a device, so Mobilewright uses the first one it finds. Add these options to target a specific device and to install a build before the test runs:
+
+```typescript
+import { defineConfig } from 'mobilewright';
+
+export default defineConfig({
+  testDir: './tests',
+  platform: 'ios',
+  deviceName: /iPhone 16/,
+  bundleId: 'com.example.myapp',
+  installApps: './builds/myapp.ipa',
+  timeout: 10_000,
+  reporter: 'html',
+});
+```
+
+`installApps` takes a path to an `.ipa` or `.apk` and installs it on the device before launching. If your app is already installed, leave it out and set `bundleId` only. [Configuration](../test/configuration.md) documents every option.
 
 ## Running tests
 
@@ -92,3 +176,11 @@ npx mobilewright show-report
 This starts a local server at `localhost:9323` with an interactive report where you can filter results, inspect errors, and view screenshots.
 
 ![HTML test report](../images/html-report.png)
+
+## What's next
+
+- [Writing Tests](./writing-tests.md) — locators, actions and assertions.
+- [Running Tests](./running-tests.md) — filtering, reporters and exit codes.
+- [Configuration](../test/configuration.md) — every config option.
+- [Inspector](../guides/inspector.md) — explore a live screen and find locators.
+- [Setting up CI](./ci.md) — run the suite on every push.

--- a/docs/src/getting-started/intro.md
+++ b/docs/src/getting-started/intro.md
@@ -109,15 +109,16 @@ tests/
   example.spec.ts
 ```
 
-The generated `mobilewright.config.ts` is deliberately minimal:
+The generated `mobilewright.config.ts` sets the target platform, app bundle ID, and device. `platform` is required — tests fail to start without it:
 
 ```typescript
 import { defineConfig } from 'mobilewright';
 
 export default defineConfig({
-  testDir: './tests',
+  platform: 'ios',
   bundleId: 'com.example.myapp',
-  reporter: 'html',
+  deviceName: /iPhone/,
+  timeout: 30_000,
 });
 ```
 
@@ -135,19 +136,17 @@ This test asserts on the text `Welcome`, which almost certainly is not on your a
 
 ## Choosing a device and installing your app
 
-The scaffolded config does not pin a device, so Mobilewright uses the first one it finds. Add these options to target a specific device and to install a build before the test runs:
+Edit `bundleId` to your app's bundle identifier and `deviceName` to match the device you want. Add `installApps` to install a build before the test runs:
 
 ```typescript
 import { defineConfig } from 'mobilewright';
 
 export default defineConfig({
-  testDir: './tests',
   platform: 'ios',
-  deviceName: /iPhone 16/,
   bundleId: 'com.example.myapp',
+  deviceName: /iPhone 16/,
   installApps: './builds/myapp.ipa',
-  timeout: 10_000,
-  reporter: 'html',
+  timeout: 30_000,
 });
 ```
 

--- a/docs/src/getting-started/intro.md
+++ b/docs/src/getting-started/intro.md
@@ -97,11 +97,6 @@ To add Mobilewright to a project that already has a `package.json`, install it d
 npm install --save-dev mobilewright @mobilewright/test
 ```
 
-Note that `npm init mobilewright@latest` and `npx mobilewright init` are different commands
-and produce different files. The former is the project scaffold described here; the latter is
-a one-shot CLI helper that drops a config and an `example.test.ts` into the current directory
-without prompting. See [Command Line](../test/cli.md#scaffold-a-project).
-
 ## Directory layout
 
 After scaffolding, your project looks like this:

--- a/docs/src/getting-started/intro.md
+++ b/docs/src/getting-started/intro.md
@@ -66,9 +66,13 @@ mobilewright doctor  v0.0.1
 
   Android
     ✓  Java (JDK)  21.0.10
+    ✓  JAVA_HOME  /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
     ✓  ANDROID_HOME  /Users/john/Library/Android/sdk
     ✓  ADB (Android Debug Bridge)  1.0.41
+    ✓  ADB Devices  0 devices connected
     ✓  Android Emulator  36.1.9.0
+    ✓  Android SDK Platforms  API 35 (latest)  [4 platforms installed]
+    ✓  Android Build Tools  35.0.0 (latest)  [3 versions installed]
 
 ────────────────────────────────────────────────────────────
   Summary  17 ok
@@ -92,6 +96,11 @@ To add Mobilewright to a project that already has a `package.json`, install it d
 ```bash
 npm install --save-dev mobilewright @mobilewright/test
 ```
+
+Note that `npm init mobilewright@latest` and `npx mobilewright init` are different commands
+and produce different files. The former is the project scaffold described here; the latter is
+a one-shot CLI helper that drops a config and an `example.test.ts` into the current directory
+without prompting. See [Command Line](../test/cli.md#scaffold-a-project).
 
 ## Directory layout
 

--- a/docs/src/getting-started/writing-tests.md
+++ b/docs/src/getting-started/writing-tests.md
@@ -144,7 +144,8 @@ test('deep link opens profile', async ({ device, screen }) => {
 
 ## Running what you wrote
 
-Save the file under your `testDir` with a `.test.ts` or `.spec.ts` suffix, then run:
+Save the file under your `testDir` with a `.test` or `.spec` suffix — `.ts`, `.js` and
+`.mjs` are all discovered — then run:
 
 ```bash
 npx mobilewright test

--- a/docs/src/getting-started/writing-tests.md
+++ b/docs/src/getting-started/writing-tests.md
@@ -141,3 +141,19 @@ test('deep link opens profile', async ({ device, screen }) => {
   await expect(screen.getByText('Profile')).toBeVisible();
 });
 ```
+
+## Running what you wrote
+
+Save the file under your `testDir` with a `.test.ts` or `.spec.ts` suffix, then run:
+
+```bash
+npx mobilewright test
+```
+
+To run just this file while you iterate:
+
+```bash
+npx mobilewright test tests/login.spec.ts
+```
+
+See [Running Tests](./running-tests.md) for filtering, reporters and exit codes.

--- a/docs/src/guides/troubleshooting.md
+++ b/docs/src/guides/troubleshooting.md
@@ -36,9 +36,13 @@ mobilewright doctor  v0.0.1
 
   Android
     ✓  Java (JDK)  21.0.10
+    ✓  JAVA_HOME  /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
     ✓  ANDROID_HOME  /Users/john/Library/Android/sdk
     ✓  ADB (Android Debug Bridge)  1.0.41
+    ✓  ADB Devices  0 devices connected
     ✓  Android Emulator  36.1.9.0
+    ✓  Android SDK Platforms  API 35 (latest)  [4 platforms installed]
+    ✓  Android Build Tools  35.0.0 (latest)  [3 versions installed]
 
 ────────────────────────────────────────────────────────────
   Summary  17 ok

--- a/docs/src/test/cli.md
+++ b/docs/src/test/cli.md
@@ -116,10 +116,15 @@ npx mobilewright doctor --category system
 
 ## Scaffold a project
 
-Create a `mobilewright.config.ts` and `example.test.ts` in the current directory:
+Drop a `mobilewright.config.ts` and an `example.test.ts` into the current directory:
 
 ```bash
-npm init mobilewright@latest
+npx mobilewright init
 ```
 
-Existing files are not overwritten.
+Existing files are not overwritten. This is a one-shot helper — it does not prompt, touch
+`package.json`, or install anything.
+
+For a full project scaffold that asks for your language, test directory and bundle ID and
+then installs the dependencies, use `npm init mobilewright@latest` instead — see
+[Installation](../getting-started/intro.md#installing-mobilewright).

--- a/docs/src/test/cli.md
+++ b/docs/src/test/cli.md
@@ -116,15 +116,13 @@ npx mobilewright doctor --category system
 
 ## Scaffold a project
 
-Drop a `mobilewright.config.ts` and an `example.test.ts` into the current directory:
-
 ```bash
-npx mobilewright init
+npm init mobilewright@latest
 ```
 
-Existing files are not overwritten. This is a one-shot helper — it does not prompt, touch
-`package.json`, or install anything.
+Prompts for TypeScript or JavaScript, the test directory (default `tests`), and the bundle
+ID of the app under test — pre-filling the bundle ID if it finds an Xcode or Gradle project
+nearby. It then writes `package.json`, `mobilewright.config.ts` and
+`tests/example.spec.ts`, and runs `npm install`.
 
-For a full project scaffold that asks for your language, test directory and bundle ID and
-then installs the dependencies, use `npm init mobilewright@latest` instead — see
-[Installation](../getting-started/intro.md#installing-mobilewright).
+See [Installation](../getting-started/intro.md) for the generated files.


### PR DESCRIPTION
## Why

A new user cannot get from `npm init` to a green test. Two problems, both on the Installation page:

**1. There are no prerequisites anywhere in Getting Started.** Xcode, a booted simulator, `ANDROID_HOME`, `adb`, a running emulator — none of them are mentioned. On a clean machine `npx mobilewright test` fails with nothing to explain why. `mobilewright doctor` already checks exactly this list, but it lives at the bottom of `guides/troubleshooting.md`, which a new user only reaches *after* the first failed run.

The page is otherwise modelled on Playwright's `/docs/intro`, which ends with a **System requirements** section. That omission costs us more than it would cost Playwright: `npx playwright install` provisions the browsers, so their happy path really does work on a clean machine. We can't provision a simulator or the Android SDK, so the requirements we don't list are exactly the ones that break the first run.

**2. The scaffold walkthrough doesn't match what the scaffold produces.** Checked against `create-mobilewright@1.0.10`:

| Page says | `npm init mobilewright@latest` actually does |
|---|---|
| non-interactive; "if either file already exists, it will be skipped" | prompts for language, test directory, and bundle ID — and runs `npm install` for you |
| `tests/example.test.ts` | `tests/example.spec.ts` |
| config with `platform`, `deviceName`, `installApps`, `timeout` | config with `testDir`, `bundleId`, `reporter` — none of the other four |
| `npm install mobilewright @mobilewright/test` first | redundant; the scaffold writes `package.json` and installs |

The "skipped" behaviour described is `mobilewright init` (the in-repo templates), not `create-mobilewright`. So someone following along sees different files than the page shows, and the config example points at `./builds/myapp.ipa`, a build they don't have.

## What changed

- **New `Requirements` section** before install. Version floors match what `doctor` enforces (`commands/doctor.ts`): Node >= 18, macOS >= 13, JDK >= 11, Windows 11 (build >= 22000). Notes that Linux does Android via the existing Docker image, and that mobilecli ships bundled so nobody installs it separately.
- **`Check your setup`** — pulls the `npx mobilewright doctor` block up from Troubleshooting, with a link back for the `--json` half.
- **Corrected `Installing Mobilewright` and `Directory layout`** to match `create-mobilewright@1.0.10`, plus the direct-install path for an existing `package.json`.
- **New `Choosing a device and installing your app`** section so `platform` / `deviceName` / `installApps` / `timeout` stay documented, now labelled as options you add rather than as the scaffold's output.
- **New `What's next`** block.
- **`writing-tests.md`** — the page walks you through writing a test and never says how to run it. Added a short section that does.

## Notes

- Docs-only; no code touched.
- Every claim was verified against `packages/mobilewright/src/{config,cli}.ts`, `commands/doctor.ts`, and `mobile-next/create-mobilewright@1.0.10`. All relative links follow the file-relative convention used in `cloud-providers/` and resolve to existing files.

## Not fixed here, still open

- **No sample app.** The scaffold asserts on the text `Welcome` against `com.example.myapp`. Playwright scaffolds against a public demo site; our equivalent would be a downloadable demo `.app`/`.apk`, or defaulting to a preinstalled system app. That needs a product call and an artifact, not a docs edit — so this PR just warns the reader that the assertion won't match their app.
- **No expected console output** for the first run. `## Running tests` still shows only a screenshot, so a reader can't tell success from silence. I didn't want to invent terminal output.
- Separately: `create-mobilewright` pins `mobilewright@0.0.51` in `createPackageJson`, while latest is `0.0.55`. Different repo, not a docs issue, but worth a look.
