### PR TITLE
chore: upgrade mobilecli to 1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3146,9 +3146,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@mobilenext/mobilecli-darwin-amd64": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-darwin-amd64/-/mobilecli-darwin-amd64-1.0.7.tgz",
-      "integrity": "sha512-v0ZuEJuZBLSLUMBg3a2dQ6Kf+AlrHTVqR5Dd1iRdaex3AiQ28aLdwf8XfOehleOrqM8g3EW2qZdaW4GIgt+csg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-darwin-amd64/-/mobilecli-darwin-amd64-1.0.8.tgz",
+      "integrity": "sha512-hL3Pnzdf/sUTzZvb9FlDFZcyT8xm+18cZ+ylFkj0uk4saPV5TCPO0+e2tADtIrGrqxcBlpk9KKaRDtqj0+pn7Q==",
       "cpu": [
         "x64"
       ],
@@ -1166,9 +1166,9 @@
       ]
     },
     "node_modules/@mobilenext/mobilecli-darwin-arm64": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-darwin-arm64/-/mobilecli-darwin-arm64-1.0.7.tgz",
-      "integrity": "sha512-DLpinZGXmiZR9+L8UFxDo29W6oVG9QtuGtAYyRAjkGUMDnxGAyRCyttEdeU2U+q89dZ/Mq0+/I5hetKjOL6SzA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-darwin-arm64/-/mobilecli-darwin-arm64-1.0.8.tgz",
+      "integrity": "sha512-oHJltkefXnAS6AbKmIMnEw45ejP/4OxdaREM7O7oMwjMP893G+PFswxv2kiW7vFQV0nwchV/qRfNBU7FRZzniA==",
       "cpu": [
         "arm64"
       ],
@@ -1179,9 +1179,9 @@
       ]
     },
     "node_modules/@mobilenext/mobilecli-linux-amd64": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-linux-amd64/-/mobilecli-linux-amd64-1.0.7.tgz",
-      "integrity": "sha512-ClCJRxuhl5yC61z48iVBWJ57gECSeW8fSwu/0yq2Idh4xA9o/fOIwCU2E9bm0JT3pDx9huxSqyuH45js1cm8hQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-linux-amd64/-/mobilecli-linux-amd64-1.0.8.tgz",
+      "integrity": "sha512-7QoiKagUbjYGp6byo7u3hGO6SulBv8VDT6ToNjmO7Y632Gm9G9jHICm0KGcqdoKWOk35jU25Hj5TBGDkjKxPqQ==",
       "cpu": [
         "x64"
       ],
@@ -1192,9 +1192,9 @@
       ]
     },
     "node_modules/@mobilenext/mobilecli-linux-arm64": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-linux-arm64/-/mobilecli-linux-arm64-1.0.7.tgz",
-      "integrity": "sha512-KdnfJ1YnzvrP6v/L7OIVo4tWPaET0jzS3HwI4NJvolCHG08ZX2u541ps+xuJCPNTxwOpUt4O8Vswu3hAR9zaWw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-linux-arm64/-/mobilecli-linux-arm64-1.0.8.tgz",
+      "integrity": "sha512-bS7TxsQXCN+CG5REj28E6qgziRz/3hMY9NQqL/Xf8Vf/rK5TOAFs9R6YJh3KBEhDU2FkWWdBcrFYJhGcTX6ZNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1205,9 +1205,9 @@
       ]
     },
     "node_modules/@mobilenext/mobilecli-windows-amd64": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-windows-amd64/-/mobilecli-windows-amd64-1.0.7.tgz",
-      "integrity": "sha512-VvQOfxpmogOAmO5cXkXwMlavAJXqencPZYD1s7cYdhewpP5SMTcafp/n2TUoBda3cJOCTK+ATehBB5UpoRdbQg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-windows-amd64/-/mobilecli-windows-amd64-1.0.8.tgz",
+      "integrity": "sha512-SD6/vE9mvq3jTmpgWXTWzTgA7aDvrORj1IRA2YYrmK9PInhCUIznjIO31PSGGJWvDbF77xk5xoxrJclfEFXoCg==",
       "cpu": [
         "x64"
       ],
@@ -1218,9 +1218,9 @@
       ]
     },
     "node_modules/@mobilenext/mobilecli-windows-arm64": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-windows-arm64/-/mobilecli-windows-arm64-1.0.7.tgz",
-      "integrity": "sha512-E6FrUFBISpRQ4afIiLQX3R/P3FhH+5vkSUYuOt4cd0eX70tXbWl0qTFcMlOaI6wI6LAgKxTOOjMnpyj11FBhGg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mobilenext/mobilecli-windows-arm64/-/mobilecli-windows-arm64-1.0.8.tgz",
+      "integrity": "sha512-QMy1n+T/e8+6LASuKOkyIHoPjpYNL+tOL5HsI40WHFAfo4V5c1IoBWJndUNA+Dk5aXmtzVAHLrFiSFg7Hgf5+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2873,20 +2873,20 @@
       }
     },
     "node_modules/mobilecli": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-1.0.7.tgz",
-      "integrity": "sha512-PGvWzReJNPLcCfosVuvEidSyxWWd3FsQVKhWxVBkS0ywPRPSJaBvloFe+Nuxt8ILtGkbRVRG0+VRIbdIcz+Gng==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-1.0.8.tgz",
+      "integrity": "sha512-fc9dYCoC2BPyIt0uWjZ1aEODtDhjzxBN3wpywr2rMb3TCzJyo+kMJ+EhDpabExZZgM9fn7Fjz6T14L71JbWAgg==",
       "license": "MIT",
       "bin": {
         "mobilecli": "index.js"
       },
       "optionalDependencies": {
-        "@mobilenext/mobilecli-darwin-amd64": "1.0.7",
-        "@mobilenext/mobilecli-darwin-arm64": "1.0.7",
-        "@mobilenext/mobilecli-linux-amd64": "1.0.7",
-        "@mobilenext/mobilecli-linux-arm64": "1.0.7",
-        "@mobilenext/mobilecli-windows-amd64": "1.0.7",
-        "@mobilenext/mobilecli-windows-arm64": "1.0.7"
+        "@mobilenext/mobilecli-darwin-amd64": "1.0.8",
+        "@mobilenext/mobilecli-darwin-arm64": "1.0.8",
+        "@mobilenext/mobilecli-linux-amd64": "1.0.8",
+        "@mobilenext/mobilecli-linux-arm64": "1.0.8",
+        "@mobilenext/mobilecli-windows-amd64": "1.0.8",
+        "@mobilenext/mobilecli-windows-arm64": "1.0.8"
       }
     },
     "node_modules/mobilewright": {
@@ -3685,7 +3685,7 @@
       "dependencies": {
         "@mobilewright/protocol": "^0.0.1",
         "debug": "^4.4.3",
-        "mobilecli": "1.0.7",
+        "mobilecli": "1.0.8",
         "ws": "^8.18.0"
       },
       "devDependencies": {

--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@mobilewright/protocol": "^0.0.1",
     "debug": "^4.4.3",
-    "mobilecli": "1.0.7",
+    "mobilecli": "1.0.8",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the mobilecli dependency in driver-mobilecli from 1.0.7 to 1.0.8 and refreshes the lockfile.