### PR TITLE
chore: require node >=20.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ await device.close();
 
 ## Prerequisites
 
-- Node.js >= 18
+- Node.js >= 20.19 (ESM-only package; older Node cannot `require()` it from a CommonJS `playwright.config`)
 - A booted iOS simulator, Android emulator, or connected real device
 
 Run `mobilewright doctor` to verify your environment is ready:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ await device.close();
 
 ## Prerequisites
 
-- Node.js >= 20.19 (ESM-only package; older Node cannot `require()` it from a CommonJS `playwright.config`)
+- Node.js >= 20.19
 - A booted iOS simulator, Android emulator, or connected real device
 
 Run `mobilewright doctor` to verify your environment is ready:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "workspaces": [
     "packages/*"

--- a/packages/driver-mobilecli/package.json
+++ b/packages/driver-mobilecli/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/driver-mobilenext/package.json
+++ b/packages/driver-mobilenext/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mobilewright-core/package.json
+++ b/packages/mobilewright-core/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mobilewright/package.json
+++ b/packages/mobilewright/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- All packages are ESM-only (`"type": "module"`, no `require` export condition). In a CommonJS project Playwright transpiles `playwright.config.ts` to CJS, so `import ... from 'mobilewright'` becomes `require('mobilewright')`, which fails with `ERR_REQUIRE_ESM` on Node 18. `require(esm)` is only available on Node 20.19+ / 22.12+.
- Bump `engines.node` to `>=20.19` in every package and document it in the README.

## Test plan
- [x] `grep -r '">=18"'` returns nothing
- [ ] `npm install` on Node 18 warns about engine mismatch