### PR TITLE
docs: add geolocation guide

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -37,6 +37,7 @@ const sidebars = {
         'guides/auto-waiting',
         'guides/deep-links',
         'guides/docker',
+        'guides/geolocation',
         'guides/inspector',
         'guides/locators',
         'guides/screenshots',

--- a/docs/src/guides/geolocation.md
+++ b/docs/src/guides/geolocation.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 10
+title: Geolocation
+---
+
+# Geolocation
+
+Use `device.setGeolocation()` to override the GPS location the device reports. Every app on the device, including your own, sees the fake coordinates until you clear the override.
+
+```typescript
+await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+```
+
+Pass `null` (or nothing) to clear the override and restore the location the device reports on its own:
+
+```typescript
+await device.setGeolocation(null);
+```
+
+Latitude must be between -90 and 90, longitude between -180 and 180. Out-of-range values throw before anything is sent to the device.
+
+## Try it: Fiji in the maps app
+
+The system maps app is installed on every device, so it's a quick way to verify the override works before wiring it into your own app.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="ios" label="iOS">
+
+```typescript
+import { test, expect } from '@mobilewright/test';
+
+test('maps app shows the overridden location', async ({ device, screen }) => {
+  await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+  await device.launchApp('com.apple.Maps');
+  await screen.getByText('Search Maps').tap();
+  await screen.getByText('Search Maps').fill('Nadi');
+  await expect(screen.getByText('Fiji')).toBeVisible();
+});
+```
+
+  </TabItem>
+  <TabItem value="android" label="Android">
+
+```typescript
+import { test, expect } from '@mobilewright/test';
+
+test('maps app shows the overridden location', async ({ device, screen }) => {
+  await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+  await device.launchApp('com.google.android.apps.maps');
+  await screen.getByText('Search here').tap();
+  await screen.getByText('Search here').fill('Nadi');
+  await expect(screen.getByText('Fiji')).toBeVisible();
+});
+```
+
+  </TabItem>
+</Tabs>
+
+Take a screenshot with `device.screenshot()` if you want to eyeball the map centered on Fiji.
+
+## Testing your app
+
+Set the location before launching your app so its first location fix already returns the fake coordinates. The override does not grant location permission; your app still has to be allowed to read location, the same way it would on a real device.
+
+```typescript
+import { test, expect } from '@mobilewright/test';
+
+test('nearby stores lists the Nadi branch', async ({ device, screen }) => {
+  await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+  await device.launchApp('com.example.app');
+  await screen.getByText('Nearby stores').tap();
+  await expect(screen.getByText('Nadi')).toBeVisible();
+});
+```
+
+To move the device mid-test, call `setGeolocation()` again with new coordinates. Apps that subscribe to location updates receive the change without a relaunch.
+
+## Clean up between tests
+
+The override outlives the test that set it. Clear it in an `afterEach` so a fake location never leaks into the next test:
+
+```typescript
+import { test } from '@mobilewright/test';
+
+test.afterEach(async ({ device }) => {
+  await device.setGeolocation(null);
+});
+```
+
+## Platform notes
+
+| Platform | Setting | Clearing |
+|---|---|---|
+| iOS simulator | Applied instantly | Restores the simulator's own location setting |
+| iOS real device, iOS 16 and older | Applied instantly and sticks on its own | Restores the real GPS location |
+| iOS real device, iOS 17 and newer | Held open for the duration of the test run | Restores the real GPS location, also happens when the run ends |
+| Android emulator | Applied instantly | An emulator has no real location to go back to, so clearing resets it to the emulator default (the Googleplex) |
+| Android real device | Mock location permission is granted to the shell and a test provider is registered | Test provider is removed and the permission is revoked |
+
+On Android real devices, no developer-options toggle is needed: mobilewright grants the mock location permission to the shell package itself, so your app does not need to be selected as the mock location app.
+
+On cloud providers, support depends on the provider. `setGeolocation()` rejects with an unsupported error when the device behind it cannot fake its location.

--- a/docs/src/guides/geolocation.md
+++ b/docs/src/guides/geolocation.md
@@ -5,7 +5,7 @@ title: Geolocation
 
 # Geolocation
 
-Use `device.setGeolocation()` to override the GPS location the device reports. Every app on the device, including your own, sees the fake coordinates until you clear the override.
+Use `device.setGeolocation()` to override the GPS location the device reports. Every app on the device that has location permission, including your own, sees the fake coordinates until you clear the override.
 
 ```typescript
 await device.setGeolocation({ latitude: 55.73511, longitude: 9.1309 });

--- a/docs/src/guides/geolocation.md
+++ b/docs/src/guides/geolocation.md
@@ -59,8 +59,6 @@ test('maps app shows the overridden location', async ({ device, screen }) => {
   </TabItem>
 </Tabs>
 
-Take a screenshot with `device.screenshot()` if you want to eyeball the map centered on Fiji.
-
 ## Testing your app
 
 Set the location before launching your app so its first location fix already returns the fake coordinates. The override does not grant location permission; your app still has to be allowed to read location, the same way it would on a real device.

--- a/docs/src/guides/geolocation.md
+++ b/docs/src/guides/geolocation.md
@@ -59,17 +59,6 @@ test('maps app shows the overridden location', async ({ device, screen }) => {
 
 Set the location before launching your app so its first location fix already returns the fake coordinates. The override does not grant location permission; your app still has to be allowed to read location, the same way it would on a real device.
 
-```typescript
-import { test, expect } from '@mobilewright/test';
-
-test('nearby stores lists the closest branch', async ({ device, screen }) => {
-  await device.setGeolocation({ latitude: 55.73511, longitude: 9.1309 });
-  await device.launchApp('com.example.app');
-  await screen.getByText('Nearby stores').tap();
-  await expect(screen.getByText('Billund')).toBeVisible();
-});
-```
-
 To move the device mid-test, call `setGeolocation()` again with new coordinates. Apps that subscribe to location updates receive the change without a relaunch.
 
 ## Clean up between tests

--- a/docs/src/guides/geolocation.md
+++ b/docs/src/guides/geolocation.md
@@ -94,6 +94,4 @@ test.afterEach(async ({ device }) => {
 | Android emulator | Applied instantly | An emulator has no real location to go back to, so clearing resets it to the emulator default (the Googleplex) |
 | Android real device | Mock location permission is granted to the shell and a test provider is registered | Test provider is removed and the permission is revoked |
 
-On Android real devices, no developer-options toggle is needed: mobilewright grants the mock location permission to the shell package itself, so your app does not need to be selected as the mock location app.
-
 On cloud providers, support depends on the provider. `setGeolocation()` rejects with an unsupported error when the device behind it cannot fake its location.

--- a/docs/src/guides/geolocation.md
+++ b/docs/src/guides/geolocation.md
@@ -8,7 +8,7 @@ title: Geolocation
 Use `device.setGeolocation()` to override the GPS location the device reports. Every app on the device, including your own, sees the fake coordinates until you clear the override.
 
 ```typescript
-await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+await device.setGeolocation({ latitude: 55.73511, longitude: 9.1309 });
 ```
 
 Pass `null` (or nothing) to clear the override and restore the location the device reports on its own:
@@ -19,9 +19,9 @@ await device.setGeolocation(null);
 
 Latitude must be between -90 and 90, longitude between -180 and 180. Out-of-range values throw before anything is sent to the device.
 
-## Try it: Fiji in the maps app
+## Try it: the maps app
 
-The system maps app is installed on every device, so it's a quick way to verify the override works before wiring it into your own app.
+The system maps app is installed on every device and centers on the current location when it opens, so it's a quick way to verify the override works before wiring it into your own app.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -33,11 +33,9 @@ import TabItem from '@theme/TabItem';
 import { test, expect } from '@mobilewright/test';
 
 test('maps app shows the overridden location', async ({ device, screen }) => {
-  await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+  await device.setGeolocation({ latitude: 55.73511, longitude: 9.1309 });
   await device.launchApp('com.apple.Maps');
-  await screen.getByText('Search Maps').tap();
-  await screen.getByText('Search Maps').fill('Nadi');
-  await expect(screen.getByText('Fiji')).toBeVisible();
+  await expect(screen.getByText('Billund')).toBeVisible();
 });
 ```
 
@@ -48,11 +46,9 @@ test('maps app shows the overridden location', async ({ device, screen }) => {
 import { test, expect } from '@mobilewright/test';
 
 test('maps app shows the overridden location', async ({ device, screen }) => {
-  await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+  await device.setGeolocation({ latitude: 55.73511, longitude: 9.1309 });
   await device.launchApp('com.google.android.apps.maps');
-  await screen.getByText('Search here').tap();
-  await screen.getByText('Search here').fill('Nadi');
-  await expect(screen.getByText('Fiji')).toBeVisible();
+  await expect(screen.getByText('Billund')).toBeVisible();
 });
 ```
 
@@ -66,11 +62,11 @@ Set the location before launching your app so its first location fix already ret
 ```typescript
 import { test, expect } from '@mobilewright/test';
 
-test('nearby stores lists the Nadi branch', async ({ device, screen }) => {
-  await device.setGeolocation({ latitude: -17.833, longitude: 177.947 });
+test('nearby stores lists the closest branch', async ({ device, screen }) => {
+  await device.setGeolocation({ latitude: 55.73511, longitude: 9.1309 });
   await device.launchApp('com.example.app');
   await screen.getByText('Nearby stores').tap();
-  await expect(screen.getByText('Nadi')).toBeVisible();
+  await expect(screen.getByText('Billund')).toBeVisible();
 });
 ```
 


### PR DESCRIPTION
## Summary
- New guide `docs/src/guides/geolocation.md`: `device.setGeolocation()` API, clearing, validation ranges
- "Try it" example with Apple Maps / Google Maps tabs, own-app example, `afterEach` cleanup
- Platform notes table: iOS simulator, iOS ≤16 / 17+ real devices, Android emulator (clear resets to Googleplex), Android real devices (mock_location appop)
- Added `guides/geolocation` to the docs sidebar

## Test plan
- [ ] Docs site builds and the Geolocation page renders under Guides
- [ ] Verify search-field labels in Apple Maps ("Search Maps") and Google Maps ("Search here") on a real device