### PR TITLE
feat: send scarf.sh pixel on mobilewright test when telemetry is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Mobilewright collects anonymous usage telemetry via PostHog and Scarf. To disabl
 MOBILEWRIGHT_DISABLE_TELEMETRY=1 npx mobilewright test
 ```
 
-When telemetry is enabled, a random identifier is generated and stored in `~/.config/mobilenext/mobilewright/config.json`. No personal information or test data is ever collected.
+When telemetry is enabled, a random identifier is generated and stored in `~/.config/mobilenext/mobilewright/config.json`. Mobilewright never sends personal information or test data. The Scarf pixel is a plain HTTP request, so Scarf receives the usual request metadata (source IP, user agent); Scarf states it does not retain raw IP addresses. Set `MOBILEWRIGHT_DISABLE_TELEMETRY` to opt out of both.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Mobile Next Cloud is the only device cloud with native Mobilewright support.
 
 ## Telemetry
 
-Mobilewright collects anonymous usage telemetry via PostHog. To disable it, set the `MOBILEWRIGHT_DISABLE_TELEMETRY` environment variable:
+Mobilewright collects anonymous usage telemetry via PostHog and Scarf. To disable it, set the `MOBILEWRIGHT_DISABLE_TELEMETRY` environment variable:
 
 ```bash
 MOBILEWRIGHT_DISABLE_TELEMETRY=1 npx mobilewright test

--- a/packages/mobilewright/src/cli.ts
+++ b/packages/mobilewright/src/cli.ts
@@ -13,7 +13,7 @@ import { MobilecliDriver, DEFAULT_URL, resolveMobilecliBinary, ensureMobilecliRe
 import { loadConfig } from './config.js';
 import { gatherChecks, renderTerminal, renderJSON } from './commands/doctor.js';
 import { brandReport } from './reporter.js';
-import { telemetry } from './telemetry.js';
+import { scarf, telemetry } from './telemetry.js';
 
 const _require = createRequire(import.meta.url);
 const _pkg = _require('../package.json') as { version: string };
@@ -98,6 +98,7 @@ program
     };
 
     telemetry('mw_test');
+    scarf();
     const status = await runAllTestsWithConfig(config, runOptions);
 
     telemetry('mw_test-ended', { Status: status });

--- a/packages/mobilewright/src/telemetry.ts
+++ b/packages/mobilewright/src/telemetry.ts
@@ -63,5 +63,9 @@ export function scarf(): void {
     return;
   }
 
-  fetch('https://static.scarf.sh/a.png?x-pxid=2c7bcfba-01fb-4460-b6e0-5cd668a00471').catch(() => {});
+  fetch('https://static.scarf.sh/a.png?x-pxid=2c7bcfba-01fb-4460-b6e0-5cd668a00471', {
+    signal: AbortSignal.timeout(5000),
+  })
+    .then((response) => response.body?.cancel())
+    .catch(() => {});
 }

--- a/packages/mobilewright/src/telemetry.ts
+++ b/packages/mobilewright/src/telemetry.ts
@@ -57,3 +57,11 @@ export function telemetry(event: string, properties: Record<string, string> = {}
     }),
   }).catch(() => {});
 }
+
+export function scarf(): void {
+  if (process.env.MOBILEWRIGHT_DISABLE_TELEMETRY) {
+    return;
+  }
+
+  fetch('https://static.scarf.sh/a.png?x-pxid=2c7bcfba-01fb-4460-b6e0-5cd668a00471').catch(() => {});
+}


### PR DESCRIPTION
Fires a scarf.sh pixel when `mobilewright test` runs, unless `MOBILEWRIGHT_DISABLE_TELEMETRY` is set.

- `scarf()` in `telemetry.ts`, fire-and-forget `fetch`, errors swallowed
- Called alongside `telemetry('mw_test')` — `test` command only
- README telemetry section now mentions PostHog and Scarf

Mirrors mobile-next/mobile-mcp#436.

## Test plan
- [x] `npx mobilewright test` registers a hit in the Scarf dashboard
- [x] `MOBILEWRIGHT_DISABLE_TELEMETRY=1 npx mobilewright test` sends nothing