### PR TITLE
chore: require node >=24.20 to match playwright 1.63 loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.19"
+        "node": ">=24.20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://mobilewright.dev",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=24.20"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Bump root `engines.node` from `>=20.19` to `>=24.20`.

## Why
Playwright 1.63 (#299) switched to Node's sync `module.registerHooks` for `.js` → `.ts` resolution and no longer patches CJS `require`. On Node < 24.20, `require.resolve()` bypasses `registerHooks`, so `defineConfig` in `packages/mobilewright/src/config.ts` fails to resolve `./device-pool/setup.js` and 28 `config.test.ts` tests fail locally. CI already runs 24.20.

Published packages' `engines` are unchanged; their `dist/` ships real `.js` files so end users are unaffected.

## Test plan
- [x] `npm test` on Node 22.23 / 24.14: 28 failures
- [x] `npm test` on Node 24.21 / 25.8: 616 passed, 1 skipped
- [x] `npm run lint`