### PR TITLE
test: extract pure fixture logic into fixture-helpers and unit test it

### DIFF
--- a/packages/test/src/fixture-helpers.test.ts
+++ b/packages/test/src/fixture-helpers.test.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '@playwright/test';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  assertValidZipFile,
+  mergeDeviceConfig,
+  assertSupportedPlatform,
+  annotationsForDevice,
+  connectOptionsFor,
+  videoPlan,
+  parseViewTreeOption,
+} from './fixture-helpers.js';
+
+function writeTempFile(name: string, bytes: Buffer): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'mw-fixture-')), name);
+  writeFileSync(path, bytes);
+  return path;
+}
+
+test.describe('assertValidZipFile', () => {
+  test('accepts a file starting with the ZIP magic bytes', () => {
+    const path = writeTempFile('app.apk', Buffer.from([0x50, 0x4b, 0x03, 0x04, 0, 0]));
+    expect(() => assertValidZipFile(path)).not.toThrow();
+  });
+
+  test('rejects a file that is not a ZIP and names the path', () => {
+    const path = writeTempFile('app.apk', Buffer.from('not a zip at all'));
+    expect(() => assertValidZipFile(path)).toThrow(`"${path}" is not a valid ZIP file`);
+  });
+});
+
+test.describe('mergeDeviceConfig', () => {
+  const config = { platform: 'ios' as const, deviceId: 'cfg-device', use: { actionTimeout: 1 }, projects: [{ name: 'android', use: { actionTimeout: 2 } }] };
+
+  test('fixture options override config values', () => {
+    const merged = mergeDeviceConfig(config, { platform: 'android', deviceId: 'opt-device' }, 'ios');
+    expect(merged.platform).toBe('android');
+    expect(merged.deviceId).toBe('opt-device');
+  });
+
+  test('undefined fixture options leave config values alone', () => {
+    const merged = mergeDeviceConfig(config, { platform: undefined, deviceId: undefined }, 'ios');
+    expect(merged.platform).toBe('ios');
+    expect(merged.deviceId).toBe('cfg-device');
+  });
+
+  test('an empty deviceId option still overrides the config deviceId', () => {
+    const merged = mergeDeviceConfig(config, { deviceId: '' }, 'ios');
+    expect(merged.deviceId).toBe('');
+  });
+
+  test('project use settings win over top-level use settings', () => {
+    const merged = mergeDeviceConfig(config, {}, 'android');
+    expect(merged.use?.actionTimeout).toBe(2);
+  });
+
+  test('an unknown project falls back to top-level use settings', () => {
+    const merged = mergeDeviceConfig(config, {}, 'nope');
+    expect(merged.use?.actionTimeout).toBe(1);
+  });
+});
+
+test.describe('assertSupportedPlatform', () => {
+  test('accepts ios and android', () => {
+    expect(assertSupportedPlatform('ios')).toBe('ios');
+    expect(assertSupportedPlatform('android')).toBe('android');
+  });
+
+  test('rejects anything else, including a missing platform', () => {
+    expect(() => assertSupportedPlatform(undefined)).toThrow('Unsupported platform: "undefined"');
+    expect(() => assertSupportedPlatform('web')).toThrow('Must be "ios" or "android"');
+  });
+});
+
+test.describe('annotationsForDevice', () => {
+  test('always records platform and id', () => {
+    expect(annotationsForDevice({ deviceId: 'd1', platform: 'ios' })).toEqual([
+      { type: 'device.platform', description: 'ios' },
+      { type: 'device.id', description: 'd1' },
+    ]);
+  });
+
+  test('records every optional field when present, id last', () => {
+    const annotations = annotationsForDevice({
+      deviceId: 'd1', platform: 'android', type: 'emulator', osVersion: '14', model: 'Pixel', driver: 'mobilecli',
+    });
+    expect(annotations.map(a => a.type)).toEqual([
+      'device.type', 'device.platform', 'device.osVersion', 'device.model', 'device.driver', 'device.id',
+    ]);
+    expect(annotations.find(a => a.type === 'device.model')?.description).toBe('Pixel');
+  });
+});
+
+test.describe('connectOptionsFor', () => {
+  test('maps allocation handle and merged config onto connectDevice options', () => {
+    const options = connectOptionsFor(
+      { deviceId: 'd1', platform: 'ios', type: 'simulator' },
+      { driver: 'drv' as any, timeout: 5, use: { actionTimeout: 1, appLaunchTimeout: 2, installTimeout: 3, animations: 'off' }, expect: { timeout: 4 } },
+    );
+    expect(options).toEqual({
+      platform: 'ios',
+      deviceId: 'd1',
+      deviceType: 'simulator',
+      driver: 'drv',
+      timeout: 5,
+      actionTimeout: 1,
+      expectTimeout: 4,
+      appLaunchTimeout: 2,
+      installTimeout: 3,
+      deviceSettings: { animations: 'off' },
+    });
+  });
+});
+
+test.describe('videoPlan', () => {
+  const outputDir = '/out';
+  const testId = 'abc';
+
+  test('does not record when video is off or unset', () => {
+    expect(videoPlan('off', outputDir, testId).shouldRecord).toBe(false);
+    expect(videoPlan(undefined, outputDir, testId).shouldRecord).toBe(false);
+  });
+
+  test('records and always attaches when video is on', () => {
+    const plan = videoPlan('on', outputDir, testId);
+    expect(plan.shouldRecord).toBe(true);
+    expect(plan.path).toBe(join('/out', 'video-abc.mp4'));
+    expect(plan.shouldAttach(false)).toBe(true);
+    expect(plan.shouldAttach(true)).toBe(true);
+  });
+
+  test('records but only attaches on failure for retain-on-failure', () => {
+    const plan = videoPlan('retain-on-failure', outputDir, testId);
+    expect(plan.shouldRecord).toBe(true);
+    expect(plan.shouldAttach(false)).toBe(false);
+    expect(plan.shouldAttach(true)).toBe(true);
+  });
+
+  test('reads the mode from the object form', () => {
+    expect(videoPlan({ mode: 'on', size: { width: 1, height: 1 } }, outputDir, testId).shouldRecord).toBe(true);
+  });
+});
+
+test.describe('parseViewTreeOption', () => {
+  test('defaults to off', () => {
+    expect(parseViewTreeOption(undefined)).toBe('off');
+  });
+
+  test('accepts on-failure', () => {
+    expect(parseViewTreeOption('on-failure')).toBe('on-failure');
+  });
+
+  test('rejects any other value', () => {
+    expect(() => parseViewTreeOption('always')).toThrow('Invalid viewTree value: "always"');
+  });
+});

--- a/packages/test/src/fixture-helpers.ts
+++ b/packages/test/src/fixture-helpers.ts
@@ -1,0 +1,101 @@
+import { openSync, readSync, closeSync } from 'node:fs';
+import { join } from 'node:path';
+import type { PlaywrightWorkerOptions } from '@playwright/test';
+import type { AllocatedDevice, Platform } from '@mobilewright/protocol';
+import type { MobilewrightConfig } from 'mobilewright';
+
+type VideoOption = PlaywrightWorkerOptions['video'] | undefined;
+type ProjectName = string;
+type DeviceOptions = {
+  platform?: Platform;
+  deviceId?: string;
+  deviceName?: RegExp;
+  deviceType?: 'simulator' | 'emulator' | 'real';
+  osVersion?: string;
+  installApps?: string | string[];
+};
+type Annotation = { type: string; description: string };
+type VideoPlan = { shouldRecord: boolean; path: string; shouldAttach(failed: boolean): boolean };
+
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+export function assertValidZipFile(path: string): void {
+  const buf = Buffer.alloc(4);
+  const fd = openSync(path, 'r');
+  try {
+    readSync(fd, buf, { offset: 0, length: 4, position: 0 });
+  } finally {
+    closeSync(fd);
+  }
+  if (!buf.equals(ZIP_MAGIC)) {
+    throw new Error(`"${path}" is not a valid ZIP file`);
+  }
+}
+
+/** Fixture options (set via `test.use`) win over config; `use` is merged from the active project. */
+export function mergeDeviceConfig(config: MobilewrightConfig, options: DeviceOptions, projectName: ProjectName): MobilewrightConfig {
+  const project = config.projects?.find(p => p.name === projectName);
+  return {
+    ...config,
+    ...(options.platform && { platform: options.platform }),
+    ...(options.deviceId !== undefined && { deviceId: options.deviceId }),
+    ...(options.deviceName && { deviceName: options.deviceName }),
+    ...(options.deviceType && { deviceType: options.deviceType }),
+    ...(options.osVersion && { osVersion: options.osVersion }),
+    ...(options.installApps !== undefined && { installApps: options.installApps }),
+    use: { ...config.use, ...project?.use },
+  };
+}
+
+export function assertSupportedPlatform(platform: string | undefined): Platform {
+  if (platform !== 'ios' && platform !== 'android') {
+    throw new Error(`Unsupported platform: "${platform}". Must be "ios" or "android".`);
+  }
+  return platform;
+}
+
+export function annotationsForDevice(handle: AllocatedDevice): Annotation[] {
+  const optional = (type: string, description: string | undefined): Annotation[] =>
+    description ? [{ type, description }] : [];
+  return [
+    ...optional('device.type', handle.type),
+    { type: 'device.platform', description: handle.platform },
+    ...optional('device.osVersion', handle.osVersion),
+    ...optional('device.model', handle.model),
+    ...optional('device.driver', handle.driver),
+    { type: 'device.id', description: handle.deviceId },
+  ];
+}
+
+export function connectOptionsFor(handle: AllocatedDevice, merged: MobilewrightConfig) {
+  return {
+    platform: handle.platform,
+    deviceId: handle.deviceId,
+    deviceType: handle.type,
+    driver: merged.driver,
+    timeout: merged.timeout,
+    actionTimeout: merged.use?.actionTimeout,
+    expectTimeout: merged.expect?.timeout,
+    appLaunchTimeout: merged.use?.appLaunchTimeout,
+    installTimeout: merged.use?.installTimeout,
+    deviceSettings: { animations: merged.use?.animations },
+  };
+}
+
+export function videoPlan(video: VideoOption, outputDir: string, testId: string): VideoPlan {
+  const mode = typeof video === 'object' ? video.mode : video;
+  const shouldRecord = mode === 'on' || mode === 'retain-on-failure';
+  return {
+    shouldRecord,
+    path: shouldRecord ? join(outputDir, `video-${testId}.mp4`) : '',
+    shouldAttach: (failed) => mode === 'on' || (mode === 'retain-on-failure' && failed),
+  };
+}
+
+export function parseViewTreeOption(value: string | undefined): 'on-failure' | 'off' {
+  const resolved = value ?? 'off';
+  if (resolved !== 'on-failure' && resolved !== 'off') {
+    throw new Error(`Invalid viewTree value: "${resolved}". Must be "on-failure" or "off".`);
+  }
+  return resolved;
+}

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -1,9 +1,8 @@
 import { test as base, type TestInfo } from '@playwright/test';
-import { createWriteStream, openSync, readSync, closeSync } from 'node:fs';
+import { createWriteStream } from 'node:fs';
 import { mkdir, unlink } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
-import { join } from 'node:path';
 import createDebug from 'debug';
 import {
   createDevicePoolClient,
@@ -14,6 +13,15 @@ import {
 } from 'mobilewright';
 import { expect, setSoftFailureHandler } from '@mobilewright/core';
 import type { Device, Screen } from '@mobilewright/core';
+import {
+  assertValidZipFile,
+  mergeDeviceConfig,
+  assertSupportedPlatform,
+  annotationsForDevice,
+  connectOptionsFor,
+  videoPlan,
+  parseViewTreeOption,
+} from './fixture-helpers.js';
 
 const debug = createDebug('mw:test:fixtures');
 
@@ -26,21 +34,6 @@ interface SoftFailureReporter {
 setSoftFailureHandler((error) => {
   (base.info() as unknown as SoftFailureReporter)._failWithError(error);
 });
-
-const ZIP_MAGIC = Buffer.from([0x50, 0x4B, 0x03, 0x04]);
-
-function assertValidZipFile(path: string): void {
-  const buf = Buffer.alloc(4);
-  const fd = openSync(path, 'r');
-  try {
-    readSync(fd, buf, { offset: 0, length: 4, position: 0 });
-  } finally {
-    closeSync(fd);
-  }
-  if (!buf.equals(ZIP_MAGIC)) {
-    throw new Error(`"${path}" is not a valid ZIP file`);
-  }
-}
 
 async function attachVideo(testInfo: TestInfo, url: string | undefined, localPath: string): Promise<void> {
   if (url) {
@@ -95,41 +88,22 @@ export const test = base.extend<MobilewrightTestFixtures>({
 
   viewTree: [async ({}, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
-    const value = config.viewTree ?? 'off';
-    if (value !== 'on-failure' && value !== 'off') {
-      throw new Error(`Invalid viewTree value: "${value}". Must be "on-failure" or "off".`);
-    }
-    
-    await use(value);
+    await use(parseViewTreeOption(config.viewTree));
   }, { option: true }],
 
   device: async ({ platform, deviceId, deviceName, deviceType, osVersion, bundleId, autoAppLaunch, installApps }, use, testInfo) => {
     const config = await loadConfig(process.cwd(), testInfo.config.configFile);
-    const project = config.projects?.find(p => p.name === testInfo.project.name);
-    const projectUse = { ...config.use, ...project?.use };
-    const merged = {
-      ...config,
-      ...(platform && { platform }),
-      ...(deviceId !== undefined && { deviceId }),
-      ...(deviceName && { deviceName }),
-      ...(deviceType && { deviceType }),
-      ...(osVersion && { osVersion }),
-      ...(installApps !== undefined && { installApps }),
-      use: projectUse,
-    };
-    
-    if (merged.platform !== 'ios' && merged.platform !== 'android') {
-      throw new Error(`Unsupported platform: "${merged.platform}". Must be "ios" or "android".`);
-    }
+    const merged = mergeDeviceConfig(config, { platform, deviceId, deviceName, deviceType, osVersion, installApps }, testInfo.project.name);
+    const supportedPlatform = assertSupportedPlatform(merged.platform);
 
     for (const appPath of toArray(merged.installApps)) {
       assertValidZipFile(appPath);
     }
 
     const client = getClient();
-    debug('allocating device (platform=%s)', merged.platform);
+    debug('allocating device (platform=%s)', supportedPlatform);
     const handle = await client.allocate({
-      platform: merged.platform,
+      platform: supportedPlatform,
       deviceNamePattern: merged.deviceName?.source,
       deviceId: merged.deviceId,
       deviceType: merged.deviceType,
@@ -137,39 +111,10 @@ export const test = base.extend<MobilewrightTestFixtures>({
     });
     debug('allocated device %s', handle.deviceId);
 
-    if (handle.type) {
-      testInfo.annotations.push({ type: 'device.type', description: handle.type });
-    }
-
-    testInfo.annotations.push({ type: 'device.platform', description: handle.platform });
-
-    if (handle.osVersion) {
-      testInfo.annotations.push({ type: 'device.osVersion', description: handle.osVersion });
-    }
-
-    if (handle.model) {
-      testInfo.annotations.push({ type: 'device.model', description: handle.model });
-    }
-
-    if (handle.driver) {
-      testInfo.annotations.push({ type: 'device.driver', description: handle.driver });
-    }
-
-    testInfo.annotations.push({ type: 'device.id', description: handle.deviceId });
+    testInfo.annotations.push(...annotationsForDevice(handle));
 
     debug('connecting to device %s', handle.deviceId);
-    const device = await connectDevice({
-      platform: handle.platform,
-      deviceId: handle.deviceId,
-      deviceType: handle.type,
-      driver: merged.driver,
-      timeout: merged.timeout,
-      actionTimeout: merged.use?.actionTimeout,
-      expectTimeout: merged.expect?.timeout,
-      appLaunchTimeout: merged.use?.appLaunchTimeout,
-      installTimeout: merged.use?.installTimeout,
-      deviceSettings: { animations: merged.use?.animations },
-    });
+    const device = await connectDevice(connectOptionsFor(handle, merged));
     debug('connected to device %s', handle.deviceId);
 
     try {
@@ -200,13 +145,10 @@ export const test = base.extend<MobilewrightTestFixtures>({
   },
 
   screen: async ({ device, video, viewTree }, use, testInfo) => {
-    const videoMode = typeof video === 'object' ? video.mode : video;
-    const shouldRecord = videoMode === 'on' || videoMode === 'retain-on-failure';
-    const videoPath = shouldRecord
-      ? join(testInfo.outputDir, `video-${testInfo.testId}.mp4`)
-      : '';
+    const plan = videoPlan(video, testInfo.outputDir, testInfo.testId);
+    const videoPath = plan.path;
 
-    if (shouldRecord) {
+    if (plan.shouldRecord) {
       try {
         await mkdir(testInfo.outputDir, { recursive: true });
         await device.startRecording({ output: videoPath });
@@ -217,13 +159,12 @@ export const test = base.extend<MobilewrightTestFixtures>({
 
     await use(device.screen);
 
-    if (shouldRecord) {
+    if (plan.shouldRecord) {
       try {
         const result = await device.stopRecording();
         const failed = testInfo.status !== testInfo.expectedStatus;
-        const shouldAttach = videoMode === 'on' || (videoMode === 'retain-on-failure' && failed);
 
-        if (shouldAttach) {
+        if (plan.shouldAttach(failed)) {
           await attachVideo(testInfo, result.url, result.output ?? videoPath);
         }
 


### PR DESCRIPTION
## Summary
- New `packages/test/src/fixture-helpers.ts`: the pure decisions from `fixtures.ts` (zip check, config merge, platform check, device annotations, connect options, video plan, viewTree parsing).
- New `fixture-helpers.test.ts`: 19 sync unit tests covering them.
- `fixtures.ts` is now glue only (+22 / -81). No behaviour change.

## Coverage
| File | Before | After |
|---|---|---|
| fixtures.ts | 28% lines, 0% funcs | 39% lines, 0% funcs |
| fixture-helpers.ts | – | 100% lines, 100% funcs |

The `device` and `screen` fixture bodies still need a real device pool, so they remain e2e-only.

## Test plan
- [x] `npm run build && npm run lint`
- [x] `npm test`: 635 passed, 1 skipped (Node 24.21)