### PR TITLE
fix: flatten screen.gesture() pointers into TapAction[] for mobilecli

### DIFF
--- a/packages/driver-mobilecli/src/driver.ts
+++ b/packages/driver-mobilecli/src/driver.ts
@@ -32,7 +32,7 @@ import type {
   WebViewInfo,
   WebViewSession,
 } from '@mobilewright/protocol';
-import { NoDeviceAvailableError, osVersionSatisfies, parseOsVersion } from '@mobilewright/protocol';
+import { NoDeviceAvailableError, gestureSequenceToTapActions, osVersionSatisfies, parseOsVersion } from '@mobilewright/protocol';
 import { RpcClient } from './rpc-client.js';
 import { resolveMobilecliBinary } from './resolve-binary.js';
 import { ensureMobilecliReachable, type ServerHandle } from './server.js';
@@ -527,7 +527,7 @@ export class MobilecliDriver implements MobilewrightSession, DeviceAllocator {
   }
 
   async gesture(gestures: GestureSequence): Promise<void> {
-    await this.call('device.io.gesture', { actions: gestures.pointers });
+    await this.call('device.io.gesture', { actions: gestureSequenceToTapActions(gestures) });
   }
 
   async pressButton(button: HardwareButton): Promise<void> {

--- a/packages/driver-mobilenext/src/driver.ts
+++ b/packages/driver-mobilenext/src/driver.ts
@@ -30,7 +30,7 @@ import type {
   TestObserver,
   ViewNode,
 } from '@mobilewright/protocol';
-import { parseOsVersion } from '@mobilewright/protocol';
+import { gestureSequenceToTapActions, parseOsVersion } from '@mobilewright/protocol';
 import { RpcClient } from './rpc-client.js';
 import { FleetApiClient, type DeviceFilter } from './fleet-api.js';
 import { MobileNextTestObserver, type MobileNextTestResultConfig } from './observer.js';
@@ -340,7 +340,7 @@ export class MobileNextDriver implements MobilewrightSession, DeviceAllocator {
   }
 
   async gesture(gestures: GestureSequence): Promise<void> {
-    await this.call('device.io.gesture', { actions: gestures.pointers });
+    await this.call('device.io.gesture', { actions: gestureSequenceToTapActions(gestures) });
   }
 
   async pressButton(button: HardwareButton): Promise<void> {

--- a/packages/mobilewright-core/src/expect.ts
+++ b/packages/mobilewright-core/src/expect.ts
@@ -28,7 +28,7 @@ interface StepCarrier {
 // a runner, soft failures throw like hard ones.
 export type SoftFailureHandler = (error: ExpectError) => void;
 
-// ponytail: module-level hook, only one runner per process
+// module-level hook, only one runner per process
 let softFailureHandler: SoftFailureHandler = (error) => { throw error; };
 
 export function setSoftFailureHandler(handler: SoftFailureHandler): void {

--- a/packages/protocol/src/gesture.test.ts
+++ b/packages/protocol/src/gesture.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { gestureSequenceToTapActions } from './gesture.js';
+
+test('a single-finger swipe becomes move, down, timed moves, up', () => {
+  const actions = gestureSequenceToTapActions({
+    pointers: [[
+      { x: 200, y: 1600, time: 0 },
+      { x: 200, y: 1000, time: 150 },
+      { x: 200, y: 400, time: 300 },
+    ]],
+  });
+
+  expect(actions).toEqual([
+    { type: 'pointerMove', x: 200, y: 1600, duration: 0 },
+    { type: 'pointerDown' },
+    { type: 'pointerMove', x: 200, y: 1000, duration: 150 },
+    { type: 'pointerMove', x: 200, y: 400, duration: 150 },
+    { type: 'pointerUp' },
+  ]);
+});
+
+test('a single point becomes a tap', () => {
+  const actions = gestureSequenceToTapActions({ pointers: [[{ x: 10, y: 20 }]] });
+  expect(actions).toEqual([
+    { type: 'pointerMove', x: 10, y: 20, duration: 0 },
+    { type: 'pointerDown' },
+    { type: 'pointerUp' },
+  ]);
+});
+
+test('points without time produce zero-duration moves', () => {
+  const actions = gestureSequenceToTapActions({ pointers: [[{ x: 0, y: 0 }, { x: 5, y: 5 }]] });
+  expect(actions[2]).toEqual({ type: 'pointerMove', x: 5, y: 5, duration: 0 });
+});
+
+test('multi-touch is rejected with a clear error', () => {
+  expect(() => gestureSequenceToTapActions({ pointers: [[{ x: 0, y: 0 }], [{ x: 1, y: 1 }]] }))
+    .toThrow('multi-touch gestures are not supported');
+});
+
+test('an empty sequence is rejected', () => {
+  expect(() => gestureSequenceToTapActions({ pointers: [] })).toThrow('at least one pointer');
+});

--- a/packages/protocol/src/gesture.ts
+++ b/packages/protocol/src/gesture.ts
@@ -1,0 +1,46 @@
+import type { GesturePoint, GestureSequence } from './types.js';
+
+/** WDA-style pointer action, the flat shape mobilecli's `device.io.gesture` expects. */
+export interface TapAction {
+  type: 'pointerMove' | 'pointerDown' | 'pointerUp' | 'pause';
+  x?: number;
+  y?: number;
+  /** Milliseconds */
+  duration?: number;
+}
+
+/**
+ * Flatten a GestureSequence (one path of timed points per finger) into the
+ * flat TapAction[] that mobilecli understands:
+ *   pointerMove(start) -> pointerDown -> pointerMove(each next point, timed) -> pointerUp
+ */
+export function gestureSequenceToTapActions(sequence: GestureSequence): TapAction[] {
+  const paths = sequence.pointers.filter(path => path.length > 0);
+  if (paths.length === 0) {
+    throw new Error('gesture requires at least one pointer with at least one point');
+  }
+
+  // TapAction has no pointer id, so mobilecli can only drive one finger.
+  // Multi-touch needs a protocol change on the mobilecli side first.
+  if (paths.length > 1) {
+    throw new Error(`multi-touch gestures are not supported by this driver (got ${paths.length} pointers)`);
+  }
+
+  return pathToTapActions(paths[0]);
+}
+
+function pathToTapActions(path: GesturePoint[]): TapAction[] {
+  const [first, ...rest] = path;
+  const start: TapAction[] = [
+    { type: 'pointerMove', x: first.x, y: first.y, duration: 0 },
+    { type: 'pointerDown' },
+  ];
+
+  const moves = rest.map((point, i) => {
+    const previousTime = path[i].time ?? 0;
+    const duration = Math.max(0, (point.time ?? previousTime) - previousTime);
+    return { type: 'pointerMove', x: point.x, y: point.y, duration } as TapAction;
+  });
+
+  return [...start, ...moves, { type: 'pointerUp' }];
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -3,3 +3,5 @@ export type * from './driver.js';
 export { NoDeviceAvailableError } from './driver.js';
 export { parseOsVersion, osVersionSatisfies } from './os-version.js';
 export type { OsVersionBound, OsVersionRange } from './os-version.js';
+export { gestureSequenceToTapActions } from './gesture.js';
+export type { TapAction } from './gesture.js';

--- a/packages/test/src/fixtures.ts
+++ b/packages/test/src/fixtures.ts
@@ -17,7 +17,7 @@ import type { Device, Screen } from '@mobilewright/core';
 
 const debug = createDebug('mw:test:fixtures');
 
-// ponytail: same private Playwright API its own expect.soft goes through
+// same private Playwright API its own expect.soft goes through
 interface SoftFailureReporter {
   _failWithError(error: Error): void;
 }


### PR DESCRIPTION
## Summary
- `screen.gesture()` sent `GesturePoint[][]` straight to `device.io.gesture`, but mobilecli expects a flat WDA-style `TapAction[]`. Every call failed with `failed to unmarshal action at index 0: json: cannot unmarshal array into Go value of type devicekit.TapAction`.
- Adds `gestureSequenceToTapActions()` in `@mobilewright/protocol`: `pointerMove(start) -> pointerDown -> timed pointerMove per point -> pointerUp`, durations derived from point `time` deltas.
- Both `driver-mobilecli` and `driver-mobilenext` now use it.
- Multi-touch throws a clear error, since `TapAction` has no pointer id.